### PR TITLE
Fix TypeError when resolver has no state

### DIFF
--- a/lib/lively/resolver.rb
+++ b/lib/lively/resolver.rb
@@ -27,7 +27,7 @@ module Lively
 		# @returns [Live::Element | Nil] The resolved element, or `nil`.
 		def call(id, data)
 			if klass = @allowed[data[:class]]
-				return klass.new(id, data, **@state)
+				return klass.new(id, data, **(@state || {}))
 			end
 		end
 	end


### PR DESCRIPTION
Hi! Spotted this from a failing CI run on main (`104` / `103 passed 1 errored`).

`Resolver#call` splats `**@state`, but the constructor allows `state` to be `nil` (and there is even a test asserting `resolver.state` is nil by default). When a resolver is built without state, splatting `nil` raises `TypeError: no implicit conversion of nil into Hash`.

The fix is a one-liner: `**(@state || {})`. That keeps the documented default (`nil` state) while making the splat safe at call time.

Verified locally with `bundle exec bake test`: all 104 tests pass.