### PR TITLE
Add simple request routing

### DIFF
--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -99,7 +99,7 @@ Application = Lively::Application[GameView, game_state: GameState.new]
 
 The `game_state:` keyword is passed to every `GameView` instance — whether created by the initial page load or by a WebSocket reconnection. This means all connected browsers share the same `GameState` object.
 
-For more complex applications, subclass {ruby Lively::Application} and override `#state`, `#allowed_views`, and `#body`:
+For more complex applications, subclass {ruby Lively::Application} and add routes with `#configure_routes`:
 
 ```ruby
 class Application < Lively::Application
@@ -116,25 +116,33 @@ class Application < Lively::Application
 		super
 	end
 	
-	def body(request)
-		case request.path
-		when "/"
-			DisplayView.new(**state)
-		when "/control"
-			ControlView.new(**state)
+	def configure_routes(router)
+		super
+		
+		router.get("/") do
+			render(DisplayView.new(**state))
+		end
+		
+		router.get("/control") do |_request, parameters|
+			render(ControlView.new(**state, mode: parameters["mode"]))
 		end
 	end
 	
+	# Unmatched routes are passed here:
 	def handle(request)
-		if body = self.body(request)
-			page = Lively::Pages::Index.new(title: "My App", body: body)
-			Protocol::HTTP::Response[200, [], [page.call]]
-		else
-			Protocol::HTTP::Response[404, [], ["Not Found"]]
-		end
+		delegate.call(request)
+	end
+	
+	private
+	
+	def render(body)
+		page = Lively::Pages::Index.new(title: "My App", body: body)
+		Protocol::HTTP::Response[200, [], [page.call]]
 	end
 end
 ```
+
+Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 
 ## Live Reloading
 

--- a/lib/lively.rb
+++ b/lib/lively.rb
@@ -6,6 +6,7 @@
 require_relative "lively/version"
 
 require_relative "lively/page"
+require_relative "lively/router"
 require_relative "lively/assets"
 require_relative "lively/application"
 

--- a/lib/lively/application.rb
+++ b/lib/lively/application.rb
@@ -8,6 +8,7 @@ require "protocol/http/middleware"
 require "async/websocket/adapters/http"
 
 require_relative "resolver"
+require_relative "router"
 require_relative "pages/index"
 require_relative "hello_world"
 
@@ -22,7 +23,7 @@ module Lively
 	#
 	# Use {.[]} to create a simple application class for a single view, optionally
 	# with shared state. For more complex applications, subclass and override
-	# {#allowed_views}, {#state}, and {#body}.
+	# {#allowed_views}, {#state}, and {#configure_routes}.
 	class Application < Protocol::HTTP::Middleware
 		VIEWS = [HelloWorld].freeze
 		STATE = {}.freeze
@@ -98,22 +99,36 @@ module Lively
 			Pages::Index.new(title: self.title, body: self.body)
 		end
 		
-		# Handle a standard HTTP request.
+		# Handle a standard HTTP request which did not match a configured route.
 		# @parameter request [Protocol::HTTP::Request] The incoming HTTP request.
 		# @returns [Protocol::HTTP::Response] The HTTP response with the rendered page.
 		def handle(request)
 			return Protocol::HTTP::Response[200, [], [self.index.call]]
 		end
 		
+		# Add the standard application routes to the given router.
+		# Override this method and call `super` to add application-specific routes.
+		# @parameter router [Router] The router to configure.
+		def configure_routes(router)
+			router.route("/live") do |request|
+				Async::WebSocket::Adapters::HTTP.open(request, &self.method(:live)) || Protocol::HTTP::Response[400]
+			end
+		end
+		
+		# The router for this application. Unmatched requests are handled separately
+		# by {#handle}.
+		# @returns [Router] The configured router.
+		def router
+			@router ||= Router.new.tap do |router|
+				configure_routes(router)
+			end
+		end
+		
 		# Process an incoming HTTP request.
 		# @parameter request [Protocol::HTTP::Request] The incoming HTTP request.
 		# @returns [Protocol::HTTP::Response] The appropriate response for the request.
 		def call(request)
-			if request.path == "/live"
-				return Async::WebSocket::Adapters::HTTP.open(request, &self.method(:live)) || Protocol::HTTP::Response[400]
-			else
-				return handle(request)
-			end
+			return router.call(request) || handle(request)
 		end
 	end
 end

--- a/lib/lively/router.rb
+++ b/lib/lively/router.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "protocol/http"
+require "protocol/url"
+
+module Lively
+	# Dispatches HTTP requests to handlers using exact path and method matches.
+	#
+	# Request targets are parsed with {Protocol::URL::Reference}. Handlers receive
+	# the original request and the decoded query parameters.
+	class Router
+		EMPTY_PARAMETERS = {}.freeze
+		ANY_METHOD = nil
+		private_constant :EMPTY_PARAMETERS, :ANY_METHOD
+		
+		# Initialize a router.
+		# @yields {|router| ...} The router to configure.
+		def initialize
+			@routes = {}
+			
+			yield self if block_given?
+		end
+		
+		# Add a route.
+		#
+		# When `methods` is omitted, the handler accepts every HTTP method. Otherwise,
+		# it may be a single method or an array of methods.
+		#
+		# @parameter path [String] The absolute path to match.
+		# @parameter methods [String | Symbol | Array(String | Symbol) | Nil] The accepted HTTP methods.
+		# @yields {|request, parameters| ...} The route handler.
+		# 	@parameter request [Protocol::HTTP::Request] The original request.
+		# 	@parameter parameters [Hash] The decoded query parameters.
+		# @returns [Router] The router.
+		def route(path, methods: nil, &handler)
+			raise ArgumentError, "A route handler is required!" unless handler
+			
+			path = route_path(path)
+			methods = route_methods(methods)
+			handlers = (@routes[path] ||= {})
+			
+			methods.each do |method|
+				if handlers.key?(method)
+					raise ArgumentError, "Route already defined for #{method || "any method"} #{path}!"
+				end
+				
+				handlers[method] = handler
+			end
+			
+			return self
+		end
+		
+		Protocol::HTTP::Methods.each do |name, method|
+			# Add a route for this HTTP method.
+			# @parameter path [String] The absolute path to match.
+			# @yields {|request, parameters| ...} The route handler.
+			# @returns [Router] The router.
+			define_method(name) do |path, &handler|
+				route(path, methods: method, &handler)
+			end
+		end
+		
+		# Dispatch a request to a matching route.
+		# @parameter request [Protocol::HTTP::Request] The request to dispatch.
+		# @returns [Protocol::HTTP::Response | Nil] The handler or error response, or `nil` when no path matches.
+		def call(request)
+			reference = parse_reference(request.path)
+			return Protocol::HTTP::Response[400] unless reference
+			
+			unless handlers = @routes[reference.path]
+				return nil
+			end
+			
+			unless handler = handlers[request.method] || handlers[ANY_METHOD]
+				allowed_methods = handlers.keys.compact.sort.join(", ")
+				return Protocol::HTTP::Response[405, [["allow", allowed_methods]]]
+			end
+			
+			parameters = parse_query(reference)
+			return Protocol::HTTP::Response[400] unless parameters
+			
+			return handler.call(request, parameters)
+		end
+		
+		private
+		
+		def route_path(path)
+			url = Protocol::URL[path]
+			
+			unless url && !url.is_a?(Protocol::URL::Absolute)
+				raise ArgumentError, "Route must be an absolute path: #{path.inspect}!"
+			end
+			
+			reference = Protocol::URL::Reference[url]
+			
+			unless reference.path.absolute?
+				raise ArgumentError, "Route must be an absolute path: #{path.inspect}!"
+			end
+			
+			if reference.query? || reference.fragment?
+				raise ArgumentError, "Route path cannot include a query or fragment: #{path.inspect}!"
+			end
+			
+			return reference.path.freeze
+		end
+		
+		def route_methods(methods)
+			return [ANY_METHOD] unless methods
+			
+			methods = Array(methods)
+			raise ArgumentError, "At least one HTTP method is required!" if methods.empty?
+			
+			return methods.map do |method|
+				raise ArgumentError, "HTTP method cannot be nil!" unless method
+				
+				method.to_s.upcase
+			end.uniq
+		end
+		
+		def parse_reference(path)
+			reference = Protocol::URL::Reference[path]
+			return if reference&.fragment?
+			
+			return reference
+		rescue ArgumentError
+			nil
+		end
+		
+		def parse_query(reference)
+			reference.parse_query! || EMPTY_PARAMETERS
+		rescue ArgumentError
+			nil
+		end
+	end
+end

--- a/lively.gemspec
+++ b/lively.gemspec
@@ -32,5 +32,6 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "falcon", "~> 0.47"
 	spec.add_dependency "io-watch"
 	spec.add_dependency "live", "~> 0.18"
+	spec.add_dependency "protocol-url", "~> 0.18"
 	spec.add_dependency "xrb"
 end

--- a/test/lively.rb
+++ b/test/lively.rb
@@ -15,6 +15,7 @@ describe Lively do
 	
 	it "loads all required components" do
 		expect(defined?(Lively::Page)).to be_truthy
+		expect(defined?(Lively::Router)).to be_truthy
 		expect(defined?(Lively::Assets)).to be_truthy
 		expect(defined?(Lively::Application)).to be_truthy
 		expect(defined?(Lively::HelloWorld)).to be_truthy

--- a/test/lively/application.rb
+++ b/test/lively/application.rb
@@ -231,6 +231,30 @@ describe Lively::Application do
 		end
 	end
 	
+	with "#router" do
+		it "is memoized" do
+			expect(application.router).to be_equal(application.router)
+		end
+		
+		it "can be extended by subclasses" do
+			application_class = Class.new(Lively::Application) do
+				def configure_routes(router)
+					super
+					
+					router.get("/example") do |_request, parameters|
+						Protocol::HTTP::Response[200, [], [parameters.fetch("message")]]
+					end
+				end
+			end
+			
+			application = application_class.new(delegate)
+			response = application.call(Protocol::HTTP::Request.new("http", "localhost", "GET", "/example?message=Hello"))
+			
+			expect(response.status).to be == 200
+			expect(response.read).to be == "Hello"
+		end
+	end
+	
 	with "#call" do
 		it "handles /live path for WebSocket connections" do
 			request = Protocol::HTTP::Request.new("http", "localhost", "GET", "/live")
@@ -240,6 +264,16 @@ describe Lively::Application do
 			response = application.call(request)
 			
 			expect(response).to be_a(Protocol::HTTP::Response)
+			expect(response.status).to be == 101
+		end
+		
+		it "handles a query on the /live path" do
+			request = Protocol::HTTP::Request.new("http", "localhost", "GET", "/live?connection=test")
+			
+			expect(Async::WebSocket::Adapters::HTTP).to receive(:open).and_return(Protocol::HTTP::Response[101, [["upgrade", "websocket"]], []])
+			
+			response = application.call(request)
+			
 			expect(response.status).to be == 101
 		end
 		

--- a/test/lively/router.rb
+++ b/test/lively/router.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "lively/router"
+
+describe Lively::Router do
+	def request(method, path)
+		Protocol::HTTP::Request.new("http", "localhost", method, path)
+	end
+	
+	with "exact routes" do
+		it "dispatches by path and method" do
+			router = subject.new do |router|
+				router.get("/example") do |request, parameters|
+					Protocol::HTTP::Response[200, [], ["#{request.method}:#{parameters.fetch("message")}"]]
+				end
+			end
+			
+			response = router.call(request("GET", "/example?message=Hello%20World"))
+			
+			expect(response.status).to be == 200
+			expect(response.read).to be == "GET:Hello World"
+		end
+		
+		it "supports nested query parameters" do
+			router = subject.new do |router|
+				router.get("/example") do |_request, parameters|
+					Protocol::HTTP::Response[200, [], [parameters.dig("user", "name")]]
+				end
+			end
+			
+			response = router.call(request("GET", "/example?user[name]=Sam"))
+			
+			expect(response.read).to be == "Sam"
+		end
+		
+		it "supports routes accepting every method" do
+			router = subject.new do |router|
+				router.route("/example") do |request|
+					Protocol::HTTP::Response[200, [], [request.method]]
+				end
+			end
+			
+			expect(router.call(request("PATCH", "/example")).read).to be == "PATCH"
+		end
+		
+		it "supports routes accepting several methods" do
+			router = subject.new do |router|
+				router.route("/example", methods: ["GET", "HEAD"]) do |request|
+					Protocol::HTTP::Response[200, [], [request.method]]
+				end
+			end
+			
+			expect(router.call(request("GET", "/example")).read).to be == "GET"
+			expect(router.call(request("HEAD", "/example")).read).to be == "HEAD"
+		end
+	end
+	
+	with "unmatched requests" do
+		it "returns nil for an unknown path" do
+			router = subject.new
+			
+			expect(router.call(request("GET", "/missing"))).to be_nil
+		end
+		
+		it "returns method not allowed for a known path" do
+			router = subject.new do |router|
+				router.get("/example"){Protocol::HTTP::Response[200]}
+				router.post("/example"){Protocol::HTTP::Response[201]}
+			end
+			
+			response = router.call(request("DELETE", "/example"))
+			
+			expect(response.status).to be == 405
+			expect(response.headers["allow"]).to be == ["GET", "POST"]
+		end
+	end
+	
+	with "invalid input" do
+		it "rejects relative route paths" do
+			expect do
+				subject.new{|router| router.get("example"){}}
+			end.to raise_exception(ArgumentError)
+		end
+		
+		it "rejects complete URLs as route paths" do
+			expect do
+				subject.new{|router| router.get("https://example.com/example"){}}
+			end.to raise_exception(ArgumentError)
+		end
+		
+		it "rejects route paths containing a query" do
+			expect do
+				subject.new{|router| router.get("/example?mode=test"){}}
+			end.to raise_exception(ArgumentError)
+		end
+		
+		it "rejects duplicate routes" do
+			expect do
+				subject.new do |router|
+					router.get("/example"){}
+					router.get("/example"){}
+				end
+			end.to raise_exception(ArgumentError)
+		end
+		
+		it "returns bad request for malformed query parameters" do
+			router = subject.new do |router|
+				router.get("/example"){Protocol::HTTP::Response[200]}
+			end
+			
+			expect(router.call(request("GET", "/example?broken=%")).status).to be == 400
+		end
+	end
+end


### PR DESCRIPTION
## Summary

- Add `Lively::Router` for exact path and HTTP method dispatch.
- Parse request targets and query parameters with `protocol-url`.
- Support method-specific and method-independent routes, returning 400/405 responses for matched invalid requests.
- Return `nil` when no path matches, leaving fallback policy to the caller.
- Integrate routing with `Lively::Application` through `#configure_routes`; `Application#call` invokes the existing `#handle` hook only when the router does not handle the request.
- Route `/live` through the same mechanism and document application routing in the getting-started guide.

Handlers receive the original request and decoded query parameters:

```ruby
router.get("/control") do |request, parameters|
  # ...
end
```

This separation keeps `Lively::Router` focused on matching and dispatch. It also allows the legacy `Application#handle` fallback to be deprecated independently rather than embedding it in the router.

## Testing

- `bundle exec bake test` (121 tests, 232 assertions)
- `bundle exec rubocop`
- `bundle exec bake decode:index:coverage lib`
- `git diff --check`