### PR TITLE
Delegate unmatched application requests

### DIFF
--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -128,11 +128,6 @@ class Application < Lively::Application
 		end
 	end
 	
-	# Unmatched routes are passed here:
-	def handle(request)
-		delegate.call(request)
-	end
-	
 	private
 	
 	def render(body)
@@ -143,6 +138,8 @@ end
 ```
 
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
+
+Requests which do not match a route are passed to the application's delegate. An application using client-side history routing can instead override `#handle` to return its index page for unmatched paths.
 
 ## Live Reloading
 

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -128,11 +128,6 @@ class Application < Lively::Application
 		end
 	end
 	
-	# Unmatched routes are passed here:
-	def handle(request)
-		delegate.call(request)
-	end
-	
 	private
 	
 	def render(body)
@@ -143,6 +138,8 @@ end
 ```
 
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
+
+Requests which do not match a route are passed to the application's delegate. An application using client-side history routing can instead override `#handle` to return its index page for unmatched paths.
 
 ## Live Reloading
 

--- a/lib/lively/application.rb
+++ b/lib/lively/application.rb
@@ -101,15 +101,19 @@ module Lively
 		
 		# Handle a standard HTTP request which did not match a configured route.
 		# @parameter request [Protocol::HTTP::Request] The incoming HTTP request.
-		# @returns [Protocol::HTTP::Response] The HTTP response with the rendered page.
+		# @returns [Protocol::HTTP::Response] The delegate response.
 		def handle(request)
-			return Protocol::HTTP::Response[200, [], [self.index.call]]
+			return delegate.call(request)
 		end
 		
 		# Add the standard application routes to the given router.
 		# Override this method and call `super` to add application-specific routes.
 		# @parameter router [Router] The router to configure.
 		def configure_routes(router)
+			router.get("/") do
+				Protocol::HTTP::Response[200, [], [self.index.call]]
+			end
+			
 			router.route("/live") do |request|
 				Async::WebSocket::Adapters::HTTP.open(request, &self.method(:live)) || Protocol::HTTP::Response[400]
 			end

--- a/test/lively/application.rb
+++ b/test/lively/application.rb
@@ -207,33 +207,27 @@ describe Lively::Application do
 	end
 	
 	with "#handle" do
-		it "returns a 200 response" do
-			response = application.handle(Protocol::HTTP::Request.new("http", "localhost", "GET", "/"))
+		it "delegates unmatched requests" do
+			response = application.handle(Protocol::HTTP::Request.new("http", "localhost", "GET", "/unknown"))
 			
 			expect(response).to be_a(Protocol::HTTP::Response)
-			expect(response.status).to be == 200
-		end
-		
-		it "returns HTML content" do
-			response = application.handle(Protocol::HTTP::Request.new("http", "localhost", "GET", "/"))
-			
-			expect(response.body).to be_a(Protocol::HTTP::Body::Buffered)
-			html = response.body.read
-			expect(html).to be_a(String)
-			expect(html).to be(:include?, "<!DOCTYPE html>")
-		end
-		
-		it "includes application title in response" do
-			response = application.handle(Protocol::HTTP::Request.new("http", "localhost", "GET", "/"))
-			html = response.body.read
-			
-			expect(html).to be(:include?, "Lively::Application")
+			expect(response.status).to be == 404
+			expect(response.read).to be == "Not Found"
 		end
 	end
 	
 	with "#router" do
 		it "is memoized" do
 			expect(application.router).to be_equal(application.router)
+		end
+		
+		it "routes the application index explicitly" do
+			response = application.router.call(Protocol::HTTP::Request.new("http", "localhost", "GET", "/"))
+			html = response.read
+			
+			expect(response.status).to be == 200
+			expect(html).to be(:include?, "<!DOCTYPE html>")
+			expect(html).to be(:include?, "Lively::Application")
 		end
 		
 		it "can be extended by subclasses" do
@@ -320,11 +314,11 @@ describe Lively::Application do
 			expect(response.read).to be(:include?, "Hello, I'm Lively!")
 		end
 		
-		it "handles different paths correctly" do
+		it "delegates unmatched paths" do
 			response = client.get("/some/other/path")
 			
-			expect(response.status).to be == 200
-			expect(response.read).to be(:include?, "Hello, I'm Lively!")
+			expect(response.status).to be == 404
+			expect(response.read).to be == "Not Found"
 		end
 	end
 end


### PR DESCRIPTION
## Summary

- register the default application index as an explicit `GET /` route
- pass unmatched requests to the middleware delegate
- document how applications can opt into SPA-style history fallback

This makes `Lively::Application` compose normally with other HTTP middleware. Previously, every unmatched path rendered the application index and the configured delegate was never consulted.

## Compatibility

Applications relying on unknown paths rendering the index can preserve that behavior by overriding `#handle`.

## Verification

- `bundle exec sus`
- `bundle exec rubocop`