### PR TITLE
Route application views explicitly

### DIFF
--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -117,29 +117,22 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		super
-		
-		router.get("/") do
-			render(DisplayView.new(**state))
+		router.get("/") do |request|
+			render_view(request, DisplayView)
 		end
 		
-		router.get("/control") do |_request, parameters|
-			render(ControlView.new(**state, mode: parameters["mode"]))
+		router.get("/control") do |request, parameters|
+			render_view(request, ControlView, mode: parameters["mode"])
 		end
-	end
-	
-	private
-	
-	def render(body)
-		page = Lively::Pages::Index.new(title: "My App", body: body)
-		Protocol::HTTP::Response[200, [], [page.call]]
 	end
 end
 ```
 
+`allowed_views` defines the view classes the live resolver may construct. Routes select which view to display at each path, including `/`. `make_view` constructs a view with shared state, `make_page` wraps it in the default page, and `render_view` composes both operations. A custom route can construct any {ruby Lively::Page} around `make_view` and call it with the request. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 
-Requests which do not match a route are passed to the application's delegate. An application using client-side history routing can instead override `#handle` to return its index page for unmatched paths.
+Requests which do not match a route are passed to the application's delegate. An application using client-side history routing can instead override `#handle` to render an application page for unmatched paths.
 
 ## Live Reloading
 

--- a/examples/chatbot/application.rb
+++ b/examples/chatbot/application.rb
@@ -140,7 +140,7 @@ class Application < Lively::Application
 		else
 			body = ChatbotView.root(conversation_id: conversation_id)
 			page = Pages::Index.new(title: self.title, body: body)
-			return Protocol::HTTP::Response[200, [], [page.call]]
+			return page.call(request)
 		end
 	end
 end

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -117,29 +117,22 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		super
-		
-		router.get("/") do
-			render(DisplayView.new(**state))
+		router.get("/") do |request|
+			render_view(request, DisplayView)
 		end
 		
-		router.get("/control") do |_request, parameters|
-			render(ControlView.new(**state, mode: parameters["mode"]))
+		router.get("/control") do |request, parameters|
+			render_view(request, ControlView, mode: parameters["mode"])
 		end
-	end
-	
-	private
-	
-	def render(body)
-		page = Lively::Pages::Index.new(title: "My App", body: body)
-		Protocol::HTTP::Response[200, [], [page.call]]
 	end
 end
 ```
 
+`allowed_views` defines the view classes the live resolver may construct. Routes select which view to display at each path, including `/`. `make_view` constructs a view with shared state, `make_page` wraps it in the default page, and `render_view` composes both operations. A custom route can construct any {ruby Lively::Page} around `make_view` and call it with the request. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 
-Requests which do not match a route are passed to the application's delegate. An application using client-side history routing can instead override `#handle` to return its index page for unmatched paths.
+Requests which do not match a route are passed to the application's delegate. An application using client-side history routing can instead override `#handle` to render an application page for unmatched paths.
 
 ## Live Reloading
 

--- a/lib/lively/application.rb
+++ b/lib/lively/application.rb
@@ -31,7 +31,7 @@ module Lively
 		# Create a new application class configured for a specific Live view tag,
 		# optionally with shared state that is passed to all views.
 		#
-		# @parameter tag [Class] The Live view class to use as the application body.
+		# @parameter tag [Class] The Live view class to render at the root route.
 		# @parameter state [Hash] Shared state to pass to all views as keyword arguments.
 		# @returns [Class] A new application class configured for the specified tag.
 		def self.[](*tags, **state)
@@ -87,16 +87,29 @@ module Lively
 			self.class.name
 		end
 		
-		# Create the body content for this application.
+		# Construct a view with shared application state.
+		# @parameter view_class [Class] The view class to construct.
+		# @parameter arguments [Hash] Additional keyword arguments for the view.
 		# @returns [Live::View] A new view instance.
-		def body
-			self.allowed_views.first.new(**self.state)
+		def make_view(view_class, **arguments)
+			view_class.new(**self.state, **arguments)
 		end
 		
-		# Create the index page for this application.
-		# @returns [Pages::Index] A new index page instance.
-		def index
-			Pages::Index.new(title: self.title, body: self.body)
+		# Construct the default page for a view.
+		# Override this to customize the document surrounding live views.
+		# @parameter view [Live::View] The root view for the page.
+		# @returns [Page] A new page instance.
+		def make_page(view)
+			Pages::Index.new(title: self.title, body: view)
+		end
+		
+		# Construct a view and its default page, then render an HTTP response.
+		# @parameter request [Protocol::HTTP::Request] The incoming request.
+		# @parameter view_class [Class] The view class to render.
+		# @parameter arguments [Hash] Additional keyword arguments for the view.
+		# @returns [Protocol::HTTP::Response] A successful HTML response.
+		def render_view(request, view_class, **arguments)
+			make_page(make_view(view_class, **arguments)).call(request)
 		end
 		
 		# Handle a standard HTTP request which did not match a configured route.
@@ -106,16 +119,12 @@ module Lively
 			return delegate.call(request)
 		end
 		
-		# Add the standard application routes to the given router.
-		# Override this method and call `super` to add application-specific routes.
+		# Add application routes to the given router.
+		# Override this method to map paths to views or other handlers.
 		# @parameter router [Router] The router to configure.
 		def configure_routes(router)
-			router.get("/") do
-				Protocol::HTTP::Response[200, [], [self.index.call]]
-			end
-			
-			router.route("/live") do |request|
-				Async::WebSocket::Adapters::HTTP.open(request, &self.method(:live)) || Protocol::HTTP::Response[400]
+			router.get("/") do |request|
+				self.render_view(request, self.allowed_views.first)
 			end
 		end
 		
@@ -124,6 +133,7 @@ module Lively
 		# @returns [Router] The configured router.
 		def router
 			@router ||= Router.new.tap do |router|
+				configure_system_routes(router)
 				configure_routes(router)
 			end
 		end
@@ -133,6 +143,16 @@ module Lively
 		# @returns [Protocol::HTTP::Response] The appropriate response for the request.
 		def call(request)
 			return router.call(request) || handle(request)
+		end
+		
+		private
+		
+		# Add framework-owned routes to the given router.
+		# @parameter router [Router] The router to configure.
+		def configure_system_routes(router)
+			router.route("/live") do |request|
+				Async::WebSocket::Adapters::HTTP.open(request, &self.method(:live)) || Protocol::HTTP::Response[400]
+			end
 		end
 	end
 end

--- a/lib/lively/page.rb
+++ b/lib/lively/page.rb
@@ -4,6 +4,7 @@
 # Copyright, 2026, by Samuel Williams.
 
 require "json"
+require "protocol/http/response"
 require "xrb/markup"
 require "xrb/tag"
 require "xrb/template"
@@ -94,10 +95,17 @@ module Lively
 			XRB::MarkupString.raw(json)
 		end
 		
-		# Render this page to a string.
+		# Render this page to an HTML string.
 		# @returns [String]
-		def call
+		def to_html
 			@template.to_string(self)
+		end
+		
+		# Render this page as an HTTP response.
+		# @parameter request [Protocol::HTTP::Request] The incoming request.
+		# @returns [Protocol::HTTP::Response] A successful HTML response.
+		def call(request)
+			Protocol::HTTP::Response[200, {"content-type" => "text/html; charset=utf-8"}, [to_html]]
 		end
 	end
 end

--- a/test/lively/application.rb
+++ b/test/lively/application.rb
@@ -38,38 +38,24 @@ describe Lively::Application do
 			expect(application_class::STATE).to be == {game: game}
 		end
 		
-		it "defines body method on instance" do
-			tag_class = Class.new(Live::View)
-			application_class = Lively::Application[tag_class]
-			instance = application_class.new(delegate)
-			
-			expect(instance).to respond_to(:body)
-		end
-		
-		it "body method creates instance of custom tag" do
-			tag_class = Class.new(Live::View)
-			application_class = Lively::Application[tag_class]
-			instance = application_class.new(delegate)
-			
-			body_instance = instance.body
-			expect(body_instance).to be_a(tag_class)
-		end
-		
-		it "passes state to body" do
-			state_value = Object.new
+		it "renders the custom view at the root route with shared state" do
 			tag_class = Class.new(Live::View) do
-				def initialize(id = self.class.unique_id, data = {}, my_state: nil)
+				def initialize(id = self.class.unique_id, data = {}, message:)
 					super(id, data)
-					@my_state = my_state
+					@message = message
 				end
-				attr :my_state
+				
+				def render(builder)
+					builder.text(@message)
+				end
 			end
 			
-			application_class = Lively::Application[tag_class, my_state: state_value]
-			instance = application_class.new(delegate)
+			application_class = Lively::Application[tag_class, message: "Custom root view"]
+			request = Protocol::HTTP::Request.new("http", "localhost", "GET", "/")
+			response = application_class.new(delegate).call(request)
 			
-			body = instance.body
-			expect(body.my_state).to be == state_value
+			expect(response.status).to be == 200
+			expect(response.read).to be(:include?, "Custom root view")
 		end
 		
 		it "resolver allows the custom tag" do
@@ -178,31 +164,60 @@ describe Lively::Application do
 		end
 	end
 	
-	with "#body" do
-		it "returns a HelloWorld instance" do
-			body = application.body
+	with "#make_view" do
+		it "constructs a view with shared state and route arguments" do
+			view_class = Class.new(Live::View) do
+				def initialize(id = self.class.unique_id, data = {}, message:, prefix:)
+					super(id, data)
+					@text = "#{prefix}: #{message}"
+				end
+				
+				attr :text
+			end
 			
-			expect(body).to be_a(Lively::HelloWorld)
+			application_class = Class.new(Lively::Application) do
+				define_method(:state) {{prefix: "Shared"}}
+			end
+			
+			view = application_class.new(delegate).make_view(view_class, message: "Hello")
+			
+			expect(view.text).to be == "Shared: Hello"
 		end
 	end
 	
-	with "#index" do
-		it "returns a Pages::Index instance" do
-			index = application.index
+	with "#make_page" do
+		it "constructs the default page around a view" do
+			view = Lively::HelloWorld.new
+			page = application.make_page(view)
 			
-			expect(index).to be_a(Lively::Pages::Index)
+			expect(page).to be_a(Lively::Pages::Index)
+			expect(page.title).to be == application.title
+			expect(page.body).to be == view
+		end
+	end
+	
+	with "#render_view" do
+		it "renders a view as an HTTP response" do
+			request = Protocol::HTTP::Request["GET", "/"]
+			response = application.render_view(request, Lively::HelloWorld)
+			
+			expect(response.status).to be == 200
+			expect(response.read).to be(:include?, "Hello, I'm Lively!")
 		end
 		
-		it "uses application title" do
-			index = application.index
+		it "uses the application page" do
+			application_class = Class.new(Lively::Application) do
+				private
+				
+				def make_page(view)
+					Lively::Pages::Index.new(title: "Custom Page", body: view)
+				end
+			end
 			
-			expect(index.title).to be == application.title
-		end
-		
-		it "uses application body" do
-			index = application.index
+			request = Protocol::HTTP::Request["GET", "/"]
+			response = application_class.new(delegate).render_view(request, Lively::HelloWorld)
 			
-			expect(index.body).to be_a(Lively::HelloWorld)
+			expect(response.read).to be(:include?, "<title>Custom Page</title>")
 		end
 	end
 	
@@ -221,7 +236,7 @@ describe Lively::Application do
 			expect(application.router).to be_equal(application.router)
 		end
 		
-		it "routes the application index explicitly" do
+		it "routes the default view explicitly" do
 			response = application.router.call(Protocol::HTTP::Request.new("http", "localhost", "GET", "/"))
 			html = response.read
 			
@@ -247,9 +262,50 @@ describe Lively::Application do
 			expect(response.status).to be == 200
 			expect(response.read).to be == "Hello"
 		end
+		
+		it "allows the root view to be selected by its route" do
+			other_view = Class.new(Live::View)
+			root_view = Class.new(Live::View) do
+				def render(builder)
+					builder.text("Selected root view")
+				end
+			end
+			
+			application_class = Class.new(Lively::Application) do
+				define_method(:allowed_views) {[other_view, root_view]}
+				
+				define_method(:configure_routes) do |router|
+					router.get("/") do |request|
+						render_view(request, root_view)
+					end
+				end
+			end
+			
+			response = application_class.new(delegate).call(Protocol::HTTP::Request.new("http", "localhost", "GET", "/"))
+			
+			expect(response.status).to be == 200
+			expect(response.read).to be(:include?, "Selected root view")
+		end
 	end
 	
 	with "#call" do
+		it "preserves system routes when application routes are replaced" do
+			application_class = Class.new(Lively::Application) do
+				def configure_routes(router)
+					router.get("/") do |request|
+						render_view(request, Lively::HelloWorld)
+					end
+				end
+			end
+			
+			request = Protocol::HTTP::Request.new("http", "localhost", "GET", "/live")
+			expect(Async::WebSocket::Adapters::HTTP).to receive(:open).and_return(Protocol::HTTP::Response[101, [["upgrade", "websocket"]], []])
+			
+			response = application_class.new(delegate).call(request)
+			
+			expect(response.status).to be == 101
+		end
+		
 		it "handles /live path for WebSocket connections" do
 			request = Protocol::HTTP::Request.new("http", "localhost", "GET", "/live")
 			

--- a/test/lively/page.rb
+++ b/test/lively/page.rb
@@ -4,6 +4,7 @@
 # Copyright, 2026, by Samuel Williams.
 
 require "lively/page"
+require "protocol/http/request"
 
 describe Lively::Page do
 	with "#initialize" do
@@ -29,7 +30,7 @@ describe Lively::Page do
 		end
 	end
 	
-	with "#call" do
+	with "#to_html" do
 		it "renders the configured document" do
 			body = Object.new
 			def body.to_html
@@ -49,7 +50,7 @@ describe Lively::Page do
 				},
 			)
 			
-			html = page.call
+			html = page.to_html
 			
 			expect(html).to be(:include?, "<!DOCTYPE html>")
 			expect(html).to be(:include?, "<title>Example</title>")
@@ -66,14 +67,14 @@ describe Lively::Page do
 		end
 		
 		it "escapes import map content for an inline script" do
-			html = subject.new(imports: {"example" => "</script><script>"}).call
+			html = subject.new(imports: {"example" => "</script><script>"}).to_html
 			
 			expect(html.scan("</script>").size).to be == 1
 			expect(html).to be(:include?, '"example": "\\u003c/script\\u003e\\u003cscript\\u003e"')
 		end
 		
 		it "omits optional document assets" do
-			html = subject.new.call
+			html = subject.new.to_html
 			
 			expect(html).not.to be(:include?, 'rel="icon"')
 			expect(html).not.to be(:include?, 'rel="stylesheet"')
@@ -93,12 +94,23 @@ describe Lively::Page do
 				body: body,
 				stylesheets: ["/site.css?one=1&two=2"],
 				body_attributes: {title: 'one & "two"'},
-			).call
+			).to_html
 			
 			expect(html).to be(:include?, "<title>&lt;Example&gt;</title>")
 			expect(html).to be(:include?, 'href="/site.css?one=1&amp;two=2"')
 			expect(html).to be(:include?, 'title="one &amp; &quot;two&quot;"')
 			expect(html).to be(:include?, "&lt;main&gt;Example&lt;/main&gt;")
+		end
+	end
+	
+	with "#call" do
+		it "returns an HTML response" do
+			request = Protocol::HTTP::Request["GET", "/"]
+			response = subject.new(title: "Example").call(request)
+			
+			expect(response.status).to be == 200
+			expect(response.headers["content-type"]).to be == "text/html; charset=utf-8"
+			expect(response.read).to be(:include?, "<title>Example</title>")
 		end
 	end
 end

--- a/test/lively/pages/index.rb
+++ b/test/lively/pages/index.rb
@@ -33,10 +33,10 @@ describe Lively::Pages::Index do
 		end
 	end
 	
-	with "#call" do
+	with "#to_html" do
 		it "generates HTML string" do
 			index = Lively::Pages::Index.new
-			html = index.call
+			html = index.to_html
 			
 			expect(html).to be(:is_a?, String)
 			expect(html).not.to be(:empty?)
@@ -44,14 +44,14 @@ describe Lively::Pages::Index do
 		
 		it "includes DOCTYPE declaration" do
 			index = Lively::Pages::Index.new
-			html = index.call
+			html = index.to_html
 			
 			expect(html).to be(:include?, "<!DOCTYPE html>")
 		end
 		
 		it "includes html structure" do
 			index = Lively::Pages::Index.new
-			html = index.call
+			html = index.to_html
 			
 			expect(html).to be(:include?, "<html>")
 			expect(html).to be(:include?, "<head>")
@@ -61,14 +61,14 @@ describe Lively::Pages::Index do
 		
 		it "includes the title in head" do
 			index = Lively::Pages::Index.new(title: "Test Title")
-			html = index.call
+			html = index.to_html
 			
 			expect(html).to be(:include?, "<title>Test Title</title>")
 		end
 		
 		it "includes viewport meta tag" do
 			index = Lively::Pages::Index.new
-			html = index.call
+			html = index.to_html
 			
 			expect(html).to be(:include?, 'name="viewport"')
 			expect(html).to be(:include?, "width=device-width")
@@ -76,14 +76,14 @@ describe Lively::Pages::Index do
 		
 		it "includes charset meta tag" do
 			index = Lively::Pages::Index.new
-			html = index.call
+			html = index.to_html
 			
 			expect(html).to be(:include?, 'charset="UTF-8"')
 		end
 		
 		it "includes static asset links" do
 			index = Lively::Pages::Index.new
-			html = index.call
+			html = index.to_html
 			
 			expect(html).to be(:include?, 'href="/_static/icon.png"')
 			expect(html).to be(:include?, 'href="/_static/site.css"')
@@ -92,7 +92,7 @@ describe Lively::Pages::Index do
 		
 		it "includes import map" do
 			index = Lively::Pages::Index.new
-			html = index.call
+			html = index.to_html
 			
 			expect(html).to be(:include?, 'type="importmap"')
 			expect(html).to be(:include?, '"live"')
@@ -101,7 +101,7 @@ describe Lively::Pages::Index do
 		
 		it "includes Live.js initialization" do
 			index = Lively::Pages::Index.new
-			html = index.call
+			html = index.to_html
 			
 			expect(html).to be(:include?, 'type="module"')
 			expect(html).to be(:include?, "application.js")
@@ -114,14 +114,14 @@ describe Lively::Pages::Index do
 			end
 			
 			index = Lively::Pages::Index.new(body: mock_body)
-			html = index.call
+			html = index.to_html
 			
 			expect(html).to be(:include?, "&lt;div&gt;Custom Body HTML&lt;/div&gt;")
 		end
 		
 		it "shows fallback message when body is nil" do
 			index = Lively::Pages::Index.new(body: nil)
-			html = index.call
+			html = index.to_html
 			
 			expect(html).to be(:include?, "No body specified!")
 		end


### PR DESCRIPTION
## Summary

- make `/` an ordinary application route instead of routing through `body` and `index`
- add `make_view`, `make_page`, and `render_view` composition primitives
- make `Page#call(request)` return its HTML response and retain string rendering as `Page#to_html`
- register the framework-owned `/live` route independently from application routes
- remove the redundant `body` and `index` interfaces
- update the multi-interface guide and chatbot example

## Validation

- `bundle exec sus` (121 tests, 241 assertions)
- `bundle exec rubocop`
- `bundle exec bake decode:index:coverage lib` (60/60 public definitions documented)