### PR TITLE
Route requests through pages

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,12 +26,6 @@ jobs:
         
         include:
           - os: ubuntu
-            ruby: truffleruby
-            experimental: true
-          - os: ubuntu
-            ruby: jruby
-            experimental: true
-          - os: ubuntu
             ruby: head
             experimental: true
     

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -117,21 +117,20 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		display_page = Lively::Pages::Index.new(title: title) do
-			resolver.make(DisplayView)
+		router.get("/") do |request|
+			body = resolver.make(DisplayView)
+			Lively::Pages::Index.new(title: title, body: body).call(request)
 		end
 		
-		control_page = Lively::Pages::Index.new(title: title) do
-			resolver.make(ControlView)
+		router.get("/control") do |request|
+			body = resolver.make(ControlView)
+			Lively::Pages::Index.new(title: title, body: body).call(request)
 		end
-		
-		router.get("/", display_page)
-		router.get("/control", control_page)
 	end
 end
 ```
 
-`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` invokes its body block for every request, allowing the application to construct a fresh root view using the shared resolver. The page itself is independent of view resolution. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+`allowed_views` defines the view classes the shared resolver may construct. Each matched route constructs its root view using the shared resolver, wraps that concrete body in a page, and invokes `Page#call(request)` to produce the response. This keeps view construction lazy without making the page body itself callable. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
 Routes match exact paths and may accept one or more HTTP methods. Handlers receive the original request and can parse query parameters when needed. Routes without an explicit method accept every method.
 

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -127,7 +127,7 @@ class Application < Lively::Application
 end
 ```
 
-`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` takes the root view class and constructs a fresh instance for every request. Custom page classes can override `views(request, parameters)` to construct zero or more views with `view`. The page and WebSocket connection use the same resolver, so initial rendering and reconnection construct views with the same shared state and allowed classes. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` implements the default page behavior: it takes the root view class and exposes a fresh instance as the page body for every request. Custom page classes can override `body(request, parameters)` when request-specific content is needed. The page and WebSocket connection use the same resolver, so initial rendering and reconnection construct views with the same shared state and allowed classes. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -82,7 +82,7 @@ class GameState
 end
 
 class GameView < Live::View
-	def initialize(id = self.class.unique_id, data = {}, game_state: nil)
+	def initialize(id, data, game_state: nil)
 		super(id, data)
 		@game_state = game_state
 	end
@@ -118,12 +118,12 @@ class Application < Lively::Application
 	
 	def configure_routes(router)
 		router.get("/") do
-			body = resolver.make(DisplayView)
+			body = resolver.root(DisplayView)
 			Lively::Pages::Index.new(title: title, body: body).call
 		end
 		
 		router.get("/control") do
-			body = resolver.make(ControlView)
+			body = resolver.root(ControlView)
 			Lively::Pages::Index.new(title: title, body: body).call
 		end
 	end

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -133,7 +133,7 @@ end
 
 `allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` invokes its body block for every request, allowing the application to construct a fresh root view using the shared resolver. The page itself is independent of view resolution. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
-Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
+Routes match exact paths and may accept one or more HTTP methods. Handlers receive the original request and can parse query parameters when needed. Routes without an explicit method accept every method.
 
 Requests which do not match a route are passed to the application's delegate. Applications that need custom fallback behavior can supply an appropriate delegate when they are constructed.
 

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -117,13 +117,9 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		display_page = Lively::Pages::Index.new(title: title, resolver: resolver) do |page|
-			page.view(DisplayView)
-		end
+		display_page = Lively::Pages::Index.new(DisplayView, title: title, resolver: resolver)
 		
-		control_page = Lively::Pages::Index.new(title: title, resolver: resolver) do |page, request, parameters|
-			page.view(ControlView, mode: parameters["mode"])
-		end
+		control_page = Lively::Pages::Index.new(ControlView, title: title, resolver: resolver)
 		
 		router.get("/", display_page)
 		router.get("/control", control_page)
@@ -131,7 +127,7 @@ class Application < Lively::Application
 end
 ```
 
-`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. The page's composition block runs for every request and composes zero or more fresh live views with `page.view`; it may also use the request and decoded query parameters. The page and WebSocket connection use the same resolver, so initial rendering and reconnection construct views with the same shared state and allowed classes. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` takes the root view class and constructs a fresh instance for every request. Custom page classes can override `views(request, parameters)` to construct zero or more views with `view`. The page and WebSocket connection use the same resolver, so initial rendering and reconnection construct views with the same shared state and allowed classes. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -117,18 +117,21 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		router.get("/") do |request|
-			render_view(request, DisplayView)
+		display_page = Lively::Pages::Index.new(title: title, resolver: resolver) do |page|
+			page.view(DisplayView)
 		end
 		
-		router.get("/control") do |request, parameters|
-			render_view(request, ControlView, mode: parameters["mode"])
+		control_page = Lively::Pages::Index.new(title: title, resolver: resolver) do |page, request, parameters|
+			page.view(ControlView, mode: parameters["mode"])
 		end
+		
+		router.get("/", display_page)
+		router.get("/control", control_page)
 	end
 end
 ```
 
-`allowed_views` defines the view classes the live resolver may construct. Routes select which view to display at each path, including `/`. `make_view` constructs a view with shared state, `make_page` wraps it in the default page, and `render_view` composes both operations. A custom route can construct any {ruby Lively::Page} around `make_view` and call it with the request. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. The page's composition block runs for every request and composes zero or more fresh live views with `page.view`; it may also use the request and decoded query parameters. The page and WebSocket connection use the same resolver, so initial rendering and reconnection construct views with the same shared state and allowed classes. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -117,9 +117,13 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		display_page = Lively::Pages::Index.new(DisplayView, title: title, resolver: resolver)
+		display_page = Lively::Pages::Index.new(title: title) do
+			resolver.make(DisplayView)
+		end
 		
-		control_page = Lively::Pages::Index.new(ControlView, title: title, resolver: resolver)
+		control_page = Lively::Pages::Index.new(title: title) do
+			resolver.make(ControlView)
+		end
 		
 		router.get("/", display_page)
 		router.get("/control", control_page)
@@ -127,7 +131,7 @@ class Application < Lively::Application
 end
 ```
 
-`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` implements the default page behavior: it takes the root view class and exposes a fresh instance as the page body for every request. Custom page classes can override `body(request, parameters)` when request-specific content is needed. The page and WebSocket connection use the same resolver, so initial rendering and reconnection construct views with the same shared state and allowed classes. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` invokes its body block for every request, allowing the application to construct a fresh root view using the shared resolver. The page itself is independent of view resolution. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -117,20 +117,20 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		router.get("/") do |request|
+		router.get("/") do
 			body = resolver.make(DisplayView)
-			Lively::Pages::Index.new(title: title, body: body).call(request)
+			Lively::Pages::Index.new(title: title, body: body).call
 		end
 		
-		router.get("/control") do |request|
+		router.get("/control") do
 			body = resolver.make(ControlView)
-			Lively::Pages::Index.new(title: title, body: body).call(request)
+			Lively::Pages::Index.new(title: title, body: body).call
 		end
 	end
 end
 ```
 
-`allowed_views` defines the view classes the shared resolver may construct. Each matched route constructs its root view using the shared resolver, wraps that concrete body in a page, and invokes `Page#call(request)` to produce the response. This keeps view construction lazy without making the page body itself callable. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+`allowed_views` defines the view classes the shared resolver may construct. Each matched route constructs its root view using the shared resolver, wraps that concrete body in a page, and invokes `Page#call` to produce the response. This keeps view construction lazy without making the page body itself callable. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
 Routes match exact paths and may accept one or more HTTP methods. Handlers receive the original request and can parse query parameters when needed. Routes without an explicit method accept every method.
 

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -135,7 +135,7 @@ end
 
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 
-Requests which do not match a route are passed to the application's delegate. An application using client-side history routing can instead override `#handle` to render an application page for unmatched paths.
+Requests which do not match a route are passed to the application's delegate. Applications that need custom fallback behavior can supply an appropriate delegate when they are constructed.
 
 ## Live Reloading
 

--- a/examples/chatbot/application.rb
+++ b/examples/chatbot/application.rb
@@ -122,28 +122,23 @@ class Application < Lively::Application
 		[ChatbotView]
 	end
 	
-	def handle(request)
-		reference = ::XRB::Reference(request.path)
-		
-		if value = reference.query[:conversation_id]
-			conversation_id = Integer(value)
-		else
-			conversation_id = nil
+	def configure_routes(router)
+		page = Pages::Index.new(title: self.title) do |_request, parameters|
+			conversation_id = Integer(parameters.fetch("conversation_id"))
+			self.resolver.make(ChatbotView, data: {conversation_id: conversation_id})
 		end
 		
-		unless conversation_id
-			reference.query[:conversation_id] = Conversation.create!(model: "llama3.1:latest").id
-			
-			Console.info(self, "Redirecting to new conversation", reference: reference)
-			
-			return ::Protocol::HTTP::Response[302, {"location" => reference.to_s}]
-		else
-			page = Pages::Index.new(
-				title: self.title
-			) do
-				self.resolver.make(ChatbotView, data: {conversation_id: conversation_id})
+		router.get("/") do |request, parameters|
+			unless parameters.key?("conversation_id")
+				reference = ::XRB::Reference(request.path)
+				reference.query[:conversation_id] = Conversation.create!(model: "llama3.1:latest").id
+				
+				Console.info(self, "Redirecting to new conversation", reference: reference)
+				
+				next ::Protocol::HTTP::Response[302, {"location" => reference.to_s}]
 			end
-			return page.call(request)
+			
+			page.call(request, parameters)
 		end
 	end
 end

--- a/examples/chatbot/application.rb
+++ b/examples/chatbot/application.rb
@@ -138,8 +138,9 @@ class Application < Lively::Application
 			
 			return ::Protocol::HTTP::Response[302, {"location" => reference.to_s}]
 		else
-			body = ChatbotView.root(conversation_id: conversation_id)
-			page = Pages::Index.new(title: self.title, body: body)
+			page = Pages::Index.new(title: self.title, resolver: self.resolver) do |page|
+				page.view(ChatbotView, data: {conversation_id: conversation_id})
+			end
 			return page.call(request)
 		end
 	end

--- a/examples/chatbot/application.rb
+++ b/examples/chatbot/application.rb
@@ -138,9 +138,12 @@ class Application < Lively::Application
 			
 			return ::Protocol::HTTP::Response[302, {"location" => reference.to_s}]
 		else
-			page = Pages::Index.new(title: self.title, resolver: self.resolver) do |page|
-				page.view(ChatbotView, data: {conversation_id: conversation_id})
-			end
+			page = Pages::Index.new(
+				ChatbotView,
+				title: self.title,
+				resolver: self.resolver,
+				view_arguments: {data: {conversation_id: conversation_id}}
+			)
 			return page.call(request)
 		end
 	end

--- a/examples/chatbot/application.rb
+++ b/examples/chatbot/application.rb
@@ -6,7 +6,7 @@
 
 require "async/ollama"
 require "markly"
-require "xrb/reference"
+require "protocol/url"
 
 require_relative "conversation"
 require_relative "toolbox"
@@ -124,15 +124,17 @@ class Application < Lively::Application
 	
 	def configure_routes(router)
 		page = Pages::Index.new(title: self.title) do |request|
-			reference = ::XRB::Reference(request.path)
-			conversation_id = Integer(reference.query.fetch(:conversation_id))
+			reference = ::Protocol::URL::Reference[request.path]
+			parameters = reference.parse_query!
+			conversation_id = Integer(parameters.fetch("conversation_id"))
 			self.resolver.make(ChatbotView, data: {conversation_id: conversation_id})
 		end
 		
 		router.get("/") do |request|
-			reference = ::XRB::Reference(request.path)
-			unless reference.query.key?(:conversation_id)
-				reference.query[:conversation_id] = Conversation.create!(model: "llama3.1:latest").id
+			reference = ::Protocol::URL::Reference[request.path]
+			parameters = reference.parse_query!
+			unless parameters.key?("conversation_id")
+				parameters["conversation_id"] = Conversation.create!(model: "llama3.1:latest").id
 				
 				Console.info(self, "Redirecting to new conversation", reference: reference)
 				

--- a/examples/chatbot/application.rb
+++ b/examples/chatbot/application.rb
@@ -136,7 +136,7 @@ class Application < Lively::Application
 			
 			conversation_id = Integer(parameters.fetch("conversation_id"))
 			body = self.resolver.make(ChatbotView, data: {conversation_id: conversation_id})
-			Pages::Index.new(title: self.title, body: body).call(request)
+			Pages::Index.new(title: self.title, body: body).call
 		end
 	end
 end

--- a/examples/chatbot/application.rb
+++ b/examples/chatbot/application.rb
@@ -139,11 +139,10 @@ class Application < Lively::Application
 			return ::Protocol::HTTP::Response[302, {"location" => reference.to_s}]
 		else
 			page = Pages::Index.new(
-				ChatbotView,
-				title: self.title,
-				resolver: self.resolver,
-				view_arguments: {data: {conversation_id: conversation_id}}
-			)
+				title: self.title
+			) do
+				self.resolver.make(ChatbotView, data: {conversation_id: conversation_id})
+			end
 			return page.call(request)
 		end
 	end

--- a/examples/chatbot/application.rb
+++ b/examples/chatbot/application.rb
@@ -123,13 +123,6 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		page = Pages::Index.new(title: self.title) do |request|
-			reference = ::Protocol::URL::Reference[request.path]
-			parameters = reference.parse_query!
-			conversation_id = Integer(parameters.fetch("conversation_id"))
-			self.resolver.make(ChatbotView, data: {conversation_id: conversation_id})
-		end
-		
 		router.get("/") do |request|
 			reference = ::Protocol::URL::Reference[request.path]
 			parameters = reference.parse_query!
@@ -141,7 +134,9 @@ class Application < Lively::Application
 				next ::Protocol::HTTP::Response[302, {"location" => reference.to_s}]
 			end
 			
-			page.call(request)
+			conversation_id = Integer(parameters.fetch("conversation_id"))
+			body = self.resolver.make(ChatbotView, data: {conversation_id: conversation_id})
+			Pages::Index.new(title: self.title, body: body).call(request)
 		end
 	end
 end

--- a/examples/chatbot/application.rb
+++ b/examples/chatbot/application.rb
@@ -135,7 +135,7 @@ class Application < Lively::Application
 			end
 			
 			conversation_id = Integer(parameters.fetch("conversation_id"))
-			body = self.resolver.make(ChatbotView, data: {conversation_id: conversation_id})
+			body = self.resolver.root(ChatbotView, data: {conversation_id: conversation_id})
 			Pages::Index.new(title: self.title, body: body).call
 		end
 	end

--- a/examples/chatbot/application.rb
+++ b/examples/chatbot/application.rb
@@ -123,14 +123,15 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		page = Pages::Index.new(title: self.title) do |_request, parameters|
-			conversation_id = Integer(parameters.fetch("conversation_id"))
+		page = Pages::Index.new(title: self.title) do |request|
+			reference = ::XRB::Reference(request.path)
+			conversation_id = Integer(reference.query.fetch(:conversation_id))
 			self.resolver.make(ChatbotView, data: {conversation_id: conversation_id})
 		end
 		
-		router.get("/") do |request, parameters|
-			unless parameters.key?("conversation_id")
-				reference = ::XRB::Reference(request.path)
+		router.get("/") do |request|
+			reference = ::XRB::Reference(request.path)
+			unless reference.query.key?(:conversation_id)
 				reference.query[:conversation_id] = Conversation.create!(model: "llama3.1:latest").id
 				
 				Console.info(self, "Redirecting to new conversation", reference: reference)
@@ -138,7 +139,7 @@ class Application < Lively::Application
 				next ::Protocol::HTTP::Response[302, {"location" => reference.to_s}]
 			end
 			
-			page.call(request, parameters)
+			page.call(request)
 		end
 	end
 end

--- a/examples/chatbot/gems.locked
+++ b/examples/chatbot/gems.locked
@@ -1,11 +1,14 @@
 PATH
   remote: ../..
   specs:
-    lively (0.16.1)
+    lively (0.21.0)
       agent-context
+      async-htty
+      async-service (~> 0.23)
       falcon (~> 0.47)
       io-watch
       live (~> 0.18)
+      protocol-url (~> 0.19)
       xrb
 
 GEM
@@ -31,12 +34,10 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     agent-context (0.3.0)
       bake (>= 0.23)
-    async (2.38.0)
+    async (2.45.1)
       console (~> 1.29)
       fiber-annotation
-      io-event (~> 1.11)
-      metrics (~> 0.12)
-      traces (~> 0.18)
+      io-event (~> 1.21)
     async-container (0.34.3)
       async (~> 2.22)
     async-http (0.94.2)
@@ -52,6 +53,11 @@ GEM
       traces (~> 0.10)
     async-http-cache (0.4.6)
       async-http (~> 0.56)
+    async-htty (0.5.0)
+      async (~> 2.39)
+      async-http (~> 0.88)
+      protocol-http (~> 0.62)
+      protocol-htty (~> 0.4)
     async-ollama (0.10.1)
       async
       async-rest
@@ -60,7 +66,7 @@ GEM
     async-rest (0.20.0)
       async-http (~> 0.42)
       protocol-url (~> 0.2)
-    async-service (0.21.0)
+    async-service (0.25.0)
       async
       async-container (~> 0.34)
       string-format (~> 0.2)
@@ -104,7 +110,7 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-endpoint (0.17.2)
-    io-event (1.14.4)
+    io-event (1.21.1)
     io-stream (0.11.1)
     io-watch (0.6.3)
     json (2.19.1)
@@ -126,17 +132,19 @@ GEM
     openssl (4.0.1)
     prism (1.9.0)
     protocol-hpack (1.5.1)
-    protocol-http (0.60.0)
+    protocol-http (0.71.0)
     protocol-http1 (0.37.0)
       protocol-http (~> 0.58)
     protocol-http2 (0.24.0)
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.47)
+    protocol-htty (0.5.0)
+      protocol-http2
     protocol-rack (0.21.1)
       io-stream (>= 0.10)
       protocol-http (~> 0.58)
       rack (>= 1.0)
-    protocol-url (0.4.0)
+    protocol-url (0.19.0)
     protocol-websocket (0.20.2)
       protocol-http (~> 0.2)
     rack (3.2.5)

--- a/examples/tower-defence/lib/data_nexus/game_view.rb
+++ b/examples/tower-defence/lib/data_nexus/game_view.rb
@@ -8,7 +8,7 @@ module DataNexus
 			"data-nexus-game"
 		end
 		
-		def initialize(id = self.class.unique_id, data = {}, controller:)
+		def initialize(id, data, controller:)
 			super(id, data)
 			@controller = controller
 			@field_width = 1280

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -117,21 +117,20 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		display_page = Lively::Pages::Index.new(title: title) do
-			resolver.make(DisplayView)
+		router.get("/") do |request|
+			body = resolver.make(DisplayView)
+			Lively::Pages::Index.new(title: title, body: body).call(request)
 		end
 		
-		control_page = Lively::Pages::Index.new(title: title) do
-			resolver.make(ControlView)
+		router.get("/control") do |request|
+			body = resolver.make(ControlView)
+			Lively::Pages::Index.new(title: title, body: body).call(request)
 		end
-		
-		router.get("/", display_page)
-		router.get("/control", control_page)
 	end
 end
 ```
 
-`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` invokes its body block for every request, allowing the application to construct a fresh root view using the shared resolver. The page itself is independent of view resolution. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+`allowed_views` defines the view classes the shared resolver may construct. Each matched route constructs its root view using the shared resolver, wraps that concrete body in a page, and invokes `Page#call(request)` to produce the response. This keeps view construction lazy without making the page body itself callable. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
 Routes match exact paths and may accept one or more HTTP methods. Handlers receive the original request and can parse query parameters when needed. Routes without an explicit method accept every method.
 

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -127,7 +127,7 @@ class Application < Lively::Application
 end
 ```
 
-`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` takes the root view class and constructs a fresh instance for every request. Custom page classes can override `views(request, parameters)` to construct zero or more views with `view`. The page and WebSocket connection use the same resolver, so initial rendering and reconnection construct views with the same shared state and allowed classes. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` implements the default page behavior: it takes the root view class and exposes a fresh instance as the page body for every request. Custom page classes can override `body(request, parameters)` when request-specific content is needed. The page and WebSocket connection use the same resolver, so initial rendering and reconnection construct views with the same shared state and allowed classes. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -82,7 +82,7 @@ class GameState
 end
 
 class GameView < Live::View
-	def initialize(id = self.class.unique_id, data = {}, game_state: nil)
+	def initialize(id, data, game_state: nil)
 		super(id, data)
 		@game_state = game_state
 	end
@@ -118,12 +118,12 @@ class Application < Lively::Application
 	
 	def configure_routes(router)
 		router.get("/") do
-			body = resolver.make(DisplayView)
+			body = resolver.root(DisplayView)
 			Lively::Pages::Index.new(title: title, body: body).call
 		end
 		
 		router.get("/control") do
-			body = resolver.make(ControlView)
+			body = resolver.root(ControlView)
 			Lively::Pages::Index.new(title: title, body: body).call
 		end
 	end

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -133,7 +133,7 @@ end
 
 `allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` invokes its body block for every request, allowing the application to construct a fresh root view using the shared resolver. The page itself is independent of view resolution. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
-Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
+Routes match exact paths and may accept one or more HTTP methods. Handlers receive the original request and can parse query parameters when needed. Routes without an explicit method accept every method.
 
 Requests which do not match a route are passed to the application's delegate. Applications that need custom fallback behavior can supply an appropriate delegate when they are constructed.
 

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -117,13 +117,9 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		display_page = Lively::Pages::Index.new(title: title, resolver: resolver) do |page|
-			page.view(DisplayView)
-		end
+		display_page = Lively::Pages::Index.new(DisplayView, title: title, resolver: resolver)
 		
-		control_page = Lively::Pages::Index.new(title: title, resolver: resolver) do |page, request, parameters|
-			page.view(ControlView, mode: parameters["mode"])
-		end
+		control_page = Lively::Pages::Index.new(ControlView, title: title, resolver: resolver)
 		
 		router.get("/", display_page)
 		router.get("/control", control_page)
@@ -131,7 +127,7 @@ class Application < Lively::Application
 end
 ```
 
-`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. The page's composition block runs for every request and composes zero or more fresh live views with `page.view`; it may also use the request and decoded query parameters. The page and WebSocket connection use the same resolver, so initial rendering and reconnection construct views with the same shared state and allowed classes. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` takes the root view class and constructs a fresh instance for every request. Custom page classes can override `views(request, parameters)` to construct zero or more views with `view`. The page and WebSocket connection use the same resolver, so initial rendering and reconnection construct views with the same shared state and allowed classes. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -117,18 +117,21 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		router.get("/") do |request|
-			render_view(request, DisplayView)
+		display_page = Lively::Pages::Index.new(title: title, resolver: resolver) do |page|
+			page.view(DisplayView)
 		end
 		
-		router.get("/control") do |request, parameters|
-			render_view(request, ControlView, mode: parameters["mode"])
+		control_page = Lively::Pages::Index.new(title: title, resolver: resolver) do |page, request, parameters|
+			page.view(ControlView, mode: parameters["mode"])
 		end
+		
+		router.get("/", display_page)
+		router.get("/control", control_page)
 	end
 end
 ```
 
-`allowed_views` defines the view classes the live resolver may construct. Routes select which view to display at each path, including `/`. `make_view` constructs a view with shared state, `make_page` wraps it in the default page, and `render_view` composes both operations. A custom route can construct any {ruby Lively::Page} around `make_view` and call it with the request. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. The page's composition block runs for every request and composes zero or more fresh live views with `page.view`; it may also use the request and decoded query parameters. The page and WebSocket connection use the same resolver, so initial rendering and reconnection construct views with the same shared state and allowed classes. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -117,9 +117,13 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		display_page = Lively::Pages::Index.new(DisplayView, title: title, resolver: resolver)
+		display_page = Lively::Pages::Index.new(title: title) do
+			resolver.make(DisplayView)
+		end
 		
-		control_page = Lively::Pages::Index.new(ControlView, title: title, resolver: resolver)
+		control_page = Lively::Pages::Index.new(title: title) do
+			resolver.make(ControlView)
+		end
 		
 		router.get("/", display_page)
 		router.get("/control", control_page)
@@ -127,7 +131,7 @@ class Application < Lively::Application
 end
 ```
 
-`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` implements the default page behavior: it takes the root view class and exposes a fresh instance as the page body for every request. Custom page classes can override `body(request, parameters)` when request-specific content is needed. The page and WebSocket connection use the same resolver, so initial rendering and reconnection construct views with the same shared state and allowed classes. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+`allowed_views` defines the view classes the shared resolver may construct. Routes select a callable page for each path. `Pages::Index` invokes its body block for every request, allowing the application to construct a fresh root view using the shared resolver. The page itself is independent of view resolution. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -117,20 +117,20 @@ class Application < Lively::Application
 	end
 	
 	def configure_routes(router)
-		router.get("/") do |request|
+		router.get("/") do
 			body = resolver.make(DisplayView)
-			Lively::Pages::Index.new(title: title, body: body).call(request)
+			Lively::Pages::Index.new(title: title, body: body).call
 		end
 		
-		router.get("/control") do |request|
+		router.get("/control") do
 			body = resolver.make(ControlView)
-			Lively::Pages::Index.new(title: title, body: body).call(request)
+			Lively::Pages::Index.new(title: title, body: body).call
 		end
 	end
 end
 ```
 
-`allowed_views` defines the view classes the shared resolver may construct. Each matched route constructs its root view using the shared resolver, wraps that concrete body in a page, and invokes `Page#call(request)` to produce the response. This keeps view construction lazy without making the page body itself callable. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
+`allowed_views` defines the view classes the shared resolver may construct. Each matched route constructs its root view using the shared resolver, wraps that concrete body in a page, and invokes `Page#call` to produce the response. This keeps view construction lazy without making the page body itself callable. Lively installs its `/live` WebSocket route independently, so overriding `configure_routes` does not remove it.
 
 Routes match exact paths and may accept one or more HTTP methods. Handlers receive the original request and can parse query parameters when needed. Routes without an explicit method accept every method.
 

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -135,7 +135,7 @@ end
 
 Routes match exact paths and may accept one or more HTTP methods. Query parameters are decoded using `protocol-url` and passed to the handler as its second argument. Routes without an explicit method accept every method.
 
-Requests which do not match a route are passed to the application's delegate. An application using client-side history routing can instead override `#handle` to render an application page for unmatched paths.
+Requests which do not match a route are passed to the application's delegate. Applications that need custom fallback behavior can supply an appropriate delegate when they are constructed.
 
 ## Live Reloading
 

--- a/lib/lively/application.rb
+++ b/lib/lively/application.rb
@@ -98,9 +98,7 @@ module Lively
 		# Override this method to map paths to views or other handlers.
 		# @parameter router [Router::Builder] The router to configure.
 		def configure_routes(router)
-			page = Pages::Index.new(title: self.title, resolver: self.resolver) do |page|
-				page.view(self.allowed_views.first)
-			end
+			page = Pages::Index.new(self.allowed_views.first, title: self.title, resolver: self.resolver)
 			
 			router.get("/", page)
 		end

--- a/lib/lively/application.rb
+++ b/lib/lively/application.rb
@@ -98,7 +98,10 @@ module Lively
 		# Override this method to map paths to views or other handlers.
 		# @parameter router [Router::Builder] The router to configure.
 		def configure_routes(router)
-			page = Pages::Index.new(self.allowed_views.first, title: self.title, resolver: self.resolver)
+			view_class = self.allowed_views.first
+			page = Pages::Index.new(title: self.title) do
+				self.resolver.make(view_class) if view_class
+			end
 			
 			router.get("/", page)
 		end

--- a/lib/lively/application.rb
+++ b/lib/lively/application.rb
@@ -83,11 +83,11 @@ module Lively
 		# @parameter router [Router::Builder] The router to configure.
 		def configure_routes(router)
 			view_class = self.allowed_views.first
-			page = Pages::Index.new(title: self.title) do
-				self.resolver.make(view_class) if view_class
-			end
 			
-			router.get("/", page)
+			router.get("/") do |request|
+				body = self.resolver.make(view_class) if view_class
+				Pages::Index.new(title: self.title, body: body).call(request)
+			end
 		end
 		
 		# The router for this application. Unmatched requests are passed to the

--- a/lib/lively/application.rb
+++ b/lib/lively/application.rb
@@ -82,9 +82,8 @@ module Lively
 		# Override this method to map paths to views or other handlers.
 		# @parameter router [Router::Builder] The router to configure.
 		def configure_routes(router)
-			view_class = self.allowed_views.first
-			
 			router.get("/") do
+				view_class = self.allowed_views.first
 				body = self.resolver.make(view_class) if view_class
 				Pages::Index.new(title: self.title, body: body).call
 			end

--- a/lib/lively/application.rb
+++ b/lib/lively/application.rb
@@ -84,9 +84,9 @@ module Lively
 		def configure_routes(router)
 			view_class = self.allowed_views.first
 			
-			router.get("/") do |request|
+			router.get("/") do
 				body = self.resolver.make(view_class) if view_class
-				Pages::Index.new(title: self.title, body: body).call(request)
+				Pages::Index.new(title: self.title, body: body).call
 			end
 		end
 		

--- a/lib/lively/application.rb
+++ b/lib/lively/application.rb
@@ -96,7 +96,7 @@ module Lively
 		
 		# Add application routes to the given router.
 		# Override this method to map paths to views or other handlers.
-		# @parameter router [Router] The router to configure.
+		# @parameter router [Router::Builder] The router to configure.
 		def configure_routes(router)
 			page = Pages::Index.new(title: self.title, resolver: self.resolver) do |page|
 				page.view(self.allowed_views.first)
@@ -109,7 +109,7 @@ module Lively
 		# by {#handle}.
 		# @returns [Router] The configured router.
 		def router
-			@router ||= Router.new.tap do |router|
+			@router ||= Router.build(Protocol::HTTP::Middleware.for(&method(:handle))) do |router|
 				configure_system_routes(router)
 				configure_routes(router)
 			end
@@ -119,13 +119,13 @@ module Lively
 		# @parameter request [Protocol::HTTP::Request] The incoming HTTP request.
 		# @returns [Protocol::HTTP::Response] The appropriate response for the request.
 		def call(request)
-			return router.call(request) || handle(request)
+			return router.call(request)
 		end
 		
 		private
 		
 		# Add framework-owned routes to the given router.
-		# @parameter router [Router] The router to configure.
+		# @parameter router [Router::Builder] The router to configure.
 		def configure_system_routes(router)
 			router.route("/live") do |request|
 				Async::WebSocket::Adapters::HTTP.open(request, &self.method(:live)) || Protocol::HTTP::Response[400]

--- a/lib/lively/application.rb
+++ b/lib/lively/application.rb
@@ -84,7 +84,7 @@ module Lively
 		def configure_routes(router)
 			router.get("/") do
 				view_class = self.allowed_views.first
-				body = self.resolver.make(view_class) if view_class
+				body = self.resolver.root(view_class) if view_class
 				Pages::Index.new(title: self.title, body: body).call
 			end
 		end

--- a/lib/lively/application.rb
+++ b/lib/lively/application.rb
@@ -23,7 +23,7 @@ module Lively
 	#
 	# Use {.[]} to create a simple application class for a single view, optionally
 	# with shared state. For more complex applications, subclass and override
-	# {#allowed_views}, {#state}, and {#configure_routes}.
+	# {#allowed_views}, {#state}, and {#configure_routes} to route requests to pages.
 	class Application < Protocol::HTTP::Middleware
 		VIEWS = [HelloWorld].freeze
 		STATE = {}.freeze
@@ -87,31 +87,6 @@ module Lively
 			self.class.name
 		end
 		
-		# Construct a view with shared application state.
-		# @parameter view_class [Class] The view class to construct.
-		# @parameter arguments [Hash] Additional keyword arguments for the view.
-		# @returns [Live::View] A new view instance.
-		def make_view(view_class, **arguments)
-			view_class.new(**self.state, **arguments)
-		end
-		
-		# Construct the default page for a view.
-		# Override this to customize the document surrounding live views.
-		# @parameter view [Live::View] The root view for the page.
-		# @returns [Page] A new page instance.
-		def make_page(view)
-			Pages::Index.new(title: self.title, body: view)
-		end
-		
-		# Construct a view and its default page, then render an HTTP response.
-		# @parameter request [Protocol::HTTP::Request] The incoming request.
-		# @parameter view_class [Class] The view class to render.
-		# @parameter arguments [Hash] Additional keyword arguments for the view.
-		# @returns [Protocol::HTTP::Response] A successful HTML response.
-		def render_view(request, view_class, **arguments)
-			make_page(make_view(view_class, **arguments)).call(request)
-		end
-		
 		# Handle a standard HTTP request which did not match a configured route.
 		# @parameter request [Protocol::HTTP::Request] The incoming HTTP request.
 		# @returns [Protocol::HTTP::Response] The delegate response.
@@ -123,9 +98,11 @@ module Lively
 		# Override this method to map paths to views or other handlers.
 		# @parameter router [Router] The router to configure.
 		def configure_routes(router)
-			router.get("/") do |request|
-				self.render_view(request, self.allowed_views.first)
+			page = Pages::Index.new(title: self.title, resolver: self.resolver) do |page|
+				page.view(self.allowed_views.first)
 			end
+			
+			router.get("/", page)
 		end
 		
 		# The router for this application. Unmatched requests are handled separately

--- a/lib/lively/application.rb
+++ b/lib/lively/application.rb
@@ -43,15 +43,6 @@ module Lively
 			return klass
 		end
 		
-		# Initialize a new Lively application.
-		# @parameter delegate [Protocol::HTTP::Middleware] The next middleware in the chain.
-		def initialize(delegate)
-			super(delegate)
-		end
-		
-		# @attribute [Protocol::HTTP::Middleware] The delegate middleware for request handling.
-		attr :delegate
-		
 		# The shared state for this application, passed to all views via the resolver.
 		# Override this in subclasses to provide custom state.
 		# @returns [Hash] Key-value pairs passed as keyword arguments to view constructors.
@@ -87,13 +78,6 @@ module Lively
 			self.class.name
 		end
 		
-		# Handle a standard HTTP request which did not match a configured route.
-		# @parameter request [Protocol::HTTP::Request] The incoming HTTP request.
-		# @returns [Protocol::HTTP::Response] The delegate response.
-		def handle(request)
-			return delegate.call(request)
-		end
-		
 		# Add application routes to the given router.
 		# Override this method to map paths to views or other handlers.
 		# @parameter router [Router::Builder] The router to configure.
@@ -106,11 +90,11 @@ module Lively
 			router.get("/", page)
 		end
 		
-		# The router for this application. Unmatched requests are handled separately
-		# by {#handle}.
+		# The router for this application. Unmatched requests are passed to the
+		# application delegate.
 		# @returns [Router] The configured router.
 		def router
-			@router ||= Router.build(Protocol::HTTP::Middleware.for(&method(:handle))) do |router|
+			@router ||= Router.build(delegate) do |router|
 				configure_system_routes(router)
 				configure_routes(router)
 			end

--- a/lib/lively/hello_world.rb
+++ b/lib/lively/hello_world.rb
@@ -64,11 +64,7 @@ module Lively
 				builder.text(<<~TEXT)
 					#!/usr/bin/env lively
 					
-					class Application < Lively::Application
-						def body
-							Lively::HelloWorld.new
-						end
-					end
+					Application = Lively::Application[Lively::HelloWorld]
 				TEXT
 			end
 			

--- a/lib/lively/page.rb
+++ b/lib/lively/page.rb
@@ -12,10 +12,9 @@ require "xrb/template"
 module Lively
 	# Represents a complete HTML document.
 	#
-	# A page combines a renderable body with the stylesheets,
+	# A page combines a callable body with the stylesheets,
 	# import map, JavaScript modules, and body attributes required to present it.
-	# Pages are callable route handlers. Subclasses can override {#body} to construct
-	# content for each request.
+	# Pages are callable route handlers. The body is constructed for each request.
 	class Page
 		TEMPLATE = XRB::Template.load_file(File.expand_path("page.xrb", __dir__))
 		
@@ -24,10 +23,11 @@ module Lively
 			# Initialize a rendering context.
 			# @parameter page [Page] The page being rendered.
 			# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-			def initialize(page, request)
+			# @parameter body [Object | Nil] The renderable document body.
+			def initialize(page, request, body)
 				@page = page
 				@request = request
-				@body_content = page.body_content(request)
+				@body = body
 			end
 			
 			# @attribute [Page] The page being rendered.
@@ -36,19 +36,21 @@ module Lively
 			# @attribute [Protocol::HTTP::Request | Nil] The incoming request.
 			attr :request
 			
-			# @attribute [Object] The rendered document body.
-			attr :body_content
+			# @attribute [Object | Nil] The renderable document body.
+			attr :body
 		end
 		
 		# Initialize a new page.
 		# @parameter title [String] The document title.
+		# @parameter body [Interface(:call) | Nil] Constructs the document body for a request.
 		# @parameter icon [String | Nil] The favicon URL.
 		# @parameter stylesheets [Array(String | Hash)] Stylesheets in document order. Hash entries specify link attributes.
 		# @parameter imports [Hash] JavaScript import map entries.
 		# @parameter modules [Array(String)] JavaScript module URLs in document order.
 		# @parameter body_attributes [Hash] Attributes applied to the body element.
-		def initialize(title: "Lively", icon: nil, stylesheets: [], imports: {}, modules: [], body_attributes: {})
+		def initialize(title: "Lively", body: nil, icon: nil, stylesheets: [], imports: {}, modules: [], body_attributes: {})
 			@title = title
+			@body = body
 			@icon = icon
 			@stylesheets = stylesheets
 			@imports = imports
@@ -59,13 +61,6 @@ module Lively
 		
 		# @attribute [String] The document title.
 		attr :title
-		
-		# Construct the renderable document body.
-		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-		# @returns [Object | Nil] The body, which must respond to `to_html`.
-		def body(request = nil)
-			return nil
-		end
 		
 		# @attribute [String | Nil] The favicon URL.
 		attr :icon
@@ -104,13 +99,6 @@ module Lively
 			XRB::Tag.closed("link", {rel: "stylesheet", type: "text/css"}.merge(attributes))
 		end
 		
-		# The rendered document body.
-		# @returns [Object]
-		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-		def body_content(request = nil)
-			return self.body(request)&.to_html || ""
-		end
-		
 		# The serialized JavaScript import map.
 		# @returns [XRB::MarkupString]
 		def import_map
@@ -124,7 +112,8 @@ module Lively
 		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
 		# @returns [String]
 		def to_html(request = nil)
-			@template.to_string(Context.new(self, request))
+			body = @body&.call(request)
+			@template.to_string(Context.new(self, request, body))
 		end
 		
 		# Render this page as an HTTP response.

--- a/lib/lively/page.rb
+++ b/lib/lively/page.rb
@@ -19,6 +19,27 @@ module Lively
 	class Page
 		TEMPLATE = XRB::Template.load_file(File.expand_path("page.xrb", __dir__))
 		
+		# The per-request state used to render a page template.
+		class Context
+			# Initialize a rendering context.
+			# @parameter page [Page] The page being rendered.
+			# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
+			def initialize(page, request)
+				@page = page
+				@request = request
+				@body_content = page.body_content(request)
+			end
+			
+			# @attribute [Page] The page being rendered.
+			attr :page
+			
+			# @attribute [Protocol::HTTP::Request | Nil] The incoming request.
+			attr :request
+			
+			# @attribute [Object] The rendered document body.
+			attr :body_content
+		end
+		
 		# Initialize a new page.
 		# @parameter title [String] The document title.
 		# @parameter icon [String | Nil] The favicon URL.
@@ -34,7 +55,6 @@ module Lively
 			@modules = modules
 			@body_attributes = body_attributes
 			@template = TEMPLATE
-			@rendered_body = nil
 		end
 		
 		# @attribute [String] The document title.
@@ -88,8 +108,6 @@ module Lively
 		# @returns [Object]
 		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
 		def body_content(request = nil)
-			return @rendered_body if @rendered_body
-			
 			return self.body(request)&.to_html || ""
 		end
 		
@@ -106,10 +124,7 @@ module Lively
 		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
 		# @returns [String]
 		def to_html(request = nil)
-			rendering = self.dup
-			rendering.instance_variable_set(:@rendered_body, body_content(request))
-			
-			@template.to_string(rendering)
+			@template.to_string(Context.new(self, request))
 		end
 		
 		# Render this page as an HTTP response.

--- a/lib/lively/page.rb
+++ b/lib/lively/page.rb
@@ -12,9 +12,9 @@ require "xrb/template"
 module Lively
 	# Represents a complete HTML document.
 	#
-	# A page combines a callable body with the stylesheets,
-	# import map, JavaScript modules, and body attributes required to present it.
-	# Pages are callable route handlers. The body is constructed for each request.
+	# A page combines a renderable body with the stylesheets, import map,
+	# JavaScript modules, and body attributes required to present it.
+	# Pages are callable route handlers.
 	class Page
 		TEMPLATE = XRB::Template.load_file(File.expand_path("page.xrb", __dir__))
 		
@@ -42,7 +42,7 @@ module Lively
 		
 		# Initialize a new page.
 		# @parameter title [String] The document title.
-		# @parameter body [Interface(:call) | Nil] Constructs the document body for a request.
+		# @parameter body [Object | Nil] The renderable document body.
 		# @parameter icon [String | Nil] The favicon URL.
 		# @parameter stylesheets [Array(String | Hash)] Stylesheets in document order. Hash entries specify link attributes.
 		# @parameter imports [Hash] JavaScript import map entries.
@@ -61,6 +61,9 @@ module Lively
 		
 		# @attribute [String] The document title.
 		attr :title
+		
+		# @attribute [Object | Nil] The renderable document body.
+		attr :body
 		
 		# @attribute [String | Nil] The favicon URL.
 		attr :icon
@@ -112,8 +115,7 @@ module Lively
 		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
 		# @returns [String]
 		def to_html(request = nil)
-			body = @body&.call(request)
-			@template.to_string(Context.new(self, request, body))
+			@template.to_string(Context.new(self, request, @body))
 		end
 		
 		# Render this page as an HTTP response.

--- a/lib/lively/page.rb
+++ b/lib/lively/page.rb
@@ -12,22 +12,27 @@ require "xrb/template"
 module Lively
 	# Represents a complete HTML document.
 	#
-	# A page combines application content with the stylesheets, import map,
-	# JavaScript modules, and body attributes required to present it. Applications
-	# can use this class directly or subclass it to provide shared defaults.
+	# A page combines application content and live views with the stylesheets,
+	# import map, JavaScript modules, and body attributes required to present it.
+	# Pages are callable route handlers. A page may be registered once with a
+	# router; its composition block constructs fresh live views for each request.
 	class Page
 		TEMPLATE = XRB::Template.load_file(File.expand_path("page.xrb", __dir__))
 		
 		# Initialize a new page.
 		# @parameter title [String] The document title.
-		# @parameter body [Object | Nil] The document body. The result of `to_html` is interpolated into the template.
+		# @parameter resolver [Resolver | Nil] The resolver used to construct live views.
+		# @parameter body [Object | Nil] Static document body content rendered before any live views.
 		# @parameter icon [String | Nil] The favicon URL.
 		# @parameter stylesheets [Array(String | Hash)] Stylesheets in document order. Hash entries specify link attributes.
 		# @parameter imports [Hash] JavaScript import map entries.
 		# @parameter modules [Array(String)] JavaScript module URLs in document order.
 		# @parameter body_attributes [Hash] Attributes applied to the body element.
-		def initialize(title: "Lively", body: nil, icon: nil, stylesheets: [], imports: {}, modules: [], body_attributes: {})
+		# @yields {|page| ...} Configures the live views composed by this page.
+		# 	@parameter page [Page] The page being configured.
+		def initialize(title: "Lively", resolver: nil, body: nil, icon: nil, stylesheets: [], imports: {}, modules: [], body_attributes: {}, &composition)
 			@title = title
+			@resolver = resolver
 			@body = body
 			@icon = icon
 			@stylesheets = stylesheets
@@ -35,10 +40,16 @@ module Lively
 			@modules = modules
 			@body_attributes = body_attributes
 			@template = TEMPLATE
+			@composition = composition
+			@views = nil
+			@rendered_body = nil
 		end
 		
 		# @attribute [String] The document title.
 		attr :title
+		
+		# @attribute [Resolver | Nil] The resolver used to construct live views.
+		attr :resolver
 		
 		# @attribute [Object | Nil] The document body.
 		attr :body
@@ -61,6 +72,35 @@ module Lively
 		# @attribute [XRB::Template] The document template.
 		attr :template
 		
+		# Construct and append a live view to the page.
+		# @parameter view_class [Class] The view class to construct.
+		# @parameter arguments [Hash] Additional keyword arguments for the view.
+		# @returns [Live::View] The constructed view.
+		# @raises [ArgumentError] If no resolver was provided or the view is not allowed.
+		def view(view_class, **arguments)
+			raise ArgumentError, "A resolver is required to construct views!" unless @resolver
+			raise RuntimeError, "Views can only be constructed while composing a page!" unless @views
+			
+			view = @resolver.make(view_class, **arguments)
+			@views << view
+			
+			return view
+		end
+		
+		# The live views composed by this page.
+		# @returns [Array(Live::View)] The views in document order.
+		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
+		# @parameter parameters [Hash] The decoded query parameters.
+		def views(request = nil, parameters = {})
+			composition = self.dup
+			composition.instance_variable_set(:@views, [])
+			composition.instance_variable_set(:@composition, nil)
+			
+			@composition&.call(composition, request, parameters)
+			
+			return composition.instance_variable_get(:@views)
+		end
+		
 		# The opening body tag including configured attributes.
 		# @returns [XRB::Tag]
 		def body_tag
@@ -80,10 +120,25 @@ module Lively
 			XRB::Tag.closed("link", {rel: "stylesheet", type: "text/css"}.merge(attributes))
 		end
 		
-		# The rendered body content.
+		# The rendered static body and live views.
 		# @returns [Object]
-		def body_content
-			@body&.to_html || "No body specified!"
+		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
+		# @parameter parameters [Hash] The decoded query parameters.
+		def body_content(request = nil, parameters = {})
+			return @rendered_body if @rendered_body
+			
+			views = self.views(request, parameters)
+			
+			XRB::Builder.fragment do |builder|
+				if @body
+					body = @body.respond_to?(:to_html) ? @body.to_html : @body
+					builder << body
+				end
+				
+				views.each do |view|
+					builder << view.to_html
+				end
+			end
 		end
 		
 		# The serialized JavaScript import map.
@@ -96,16 +151,22 @@ module Lively
 		end
 		
 		# Render this page to an HTML string.
+		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
+		# @parameter parameters [Hash] The decoded query parameters.
 		# @returns [String]
-		def to_html
-			@template.to_string(self)
+		def to_html(request = nil, parameters = {})
+			rendering = self.dup
+			rendering.instance_variable_set(:@rendered_body, body_content(request, parameters))
+			
+			@template.to_string(rendering)
 		end
 		
 		# Render this page as an HTTP response.
 		# @parameter request [Protocol::HTTP::Request] The incoming request.
 		# @returns [Protocol::HTTP::Response] A successful HTML response.
-		def call(request)
-			Protocol::HTTP::Response[200, {"content-type" => "text/html; charset=utf-8"}, [to_html]]
+		# @parameter parameters [Hash] The decoded query parameters.
+		def call(request, parameters = {})
+			Protocol::HTTP::Response[200, {"content-type" => "text/html; charset=utf-8"}, [to_html(request, parameters)]]
 		end
 	end
 end

--- a/lib/lively/page.rb
+++ b/lib/lively/page.rb
@@ -14,24 +14,28 @@ module Lively
 	#
 	# A page combines a renderable body with the stylesheets,
 	# import map, JavaScript modules, and body attributes required to present it.
-	# Pages are callable route handlers. Subclasses can override {#body} to
-	# construct fresh content for each request.
+	# Pages are callable route handlers. The body can be a fixed object or constructed
+	# for each request using a block.
 	class Page
 		TEMPLATE = XRB::Template.load_file(File.expand_path("page.xrb", __dir__))
 		
 		# Initialize a new page.
 		# @parameter title [String] The document title.
-		# @parameter resolver [Resolver | Nil] The resolver used to construct live views.
 		# @parameter body [Object | Nil] The document body. It must respond to `to_html`.
 		# @parameter icon [String | Nil] The favicon URL.
 		# @parameter stylesheets [Array(String | Hash)] Stylesheets in document order. Hash entries specify link attributes.
 		# @parameter imports [Hash] JavaScript import map entries.
 		# @parameter modules [Array(String)] JavaScript module URLs in document order.
 		# @parameter body_attributes [Hash] Attributes applied to the body element.
-		def initialize(title: "Lively", resolver: nil, body: nil, icon: nil, stylesheets: [], imports: {}, modules: [], body_attributes: {})
+		# @yields {|request, parameters| ...} Constructs the document body for a request.
+		# 	@parameter request [Protocol::HTTP::Request | Nil] The incoming request.
+		# 	@parameter parameters [Hash] The decoded query parameters.
+		# 	@returns [Object | Nil] The document body.
+		def initialize(title: "Lively", body: nil, icon: nil, stylesheets: [], imports: {}, modules: [], body_attributes: {}, &block)
+			raise ArgumentError, "Provide a body or block, not both!" if body && block
+			
 			@title = title
-			@resolver = resolver
-			@body = body
+			@body = block || proc{|_request, _parameters| body}
 			@icon = icon
 			@stylesheets = stylesheets
 			@imports = imports
@@ -44,16 +48,12 @@ module Lively
 		# @attribute [String] The document title.
 		attr :title
 		
-		# @attribute [Resolver | Nil] The resolver used to construct live views.
-		attr :resolver
-		
-		# The renderable document body. Subclasses can override this method to
-		# construct request-specific content.
+		# Construct the renderable document body.
 		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
 		# @parameter parameters [Hash] The decoded query parameters.
 		# @returns [Object | Nil] The body, which must respond to `to_html`.
 		def body(request = nil, parameters = {})
-			return @body
+			return @body.call(request, parameters)
 		end
 		
 		# @attribute [String | Nil] The favicon URL.

--- a/lib/lively/page.rb
+++ b/lib/lively/page.rb
@@ -14,14 +14,13 @@ module Lively
 	#
 	# A page combines a renderable body with the stylesheets,
 	# import map, JavaScript modules, and body attributes required to present it.
-	# Pages are callable route handlers. The body can be a fixed object or constructed
-	# for each request using a block.
+	# Pages are callable route handlers. The body is constructed for each request
+	# using a block.
 	class Page
 		TEMPLATE = XRB::Template.load_file(File.expand_path("page.xrb", __dir__))
 		
 		# Initialize a new page.
 		# @parameter title [String] The document title.
-		# @parameter body [Object | Nil] The document body. It must respond to `to_html`.
 		# @parameter icon [String | Nil] The favicon URL.
 		# @parameter stylesheets [Array(String | Hash)] Stylesheets in document order. Hash entries specify link attributes.
 		# @parameter imports [Hash] JavaScript import map entries.
@@ -31,11 +30,9 @@ module Lively
 		# 	@parameter request [Protocol::HTTP::Request | Nil] The incoming request.
 		# 	@parameter parameters [Hash] The decoded query parameters.
 		# 	@returns [Object | Nil] The document body.
-		def initialize(title: "Lively", body: nil, icon: nil, stylesheets: [], imports: {}, modules: [], body_attributes: {}, &block)
-			raise ArgumentError, "Provide a body or block, not both!" if body && block
-			
+		def initialize(title: "Lively", icon: nil, stylesheets: [], imports: {}, modules: [], body_attributes: {}, &body)
 			@title = title
-			@body = block || proc{|_request, _parameters| body}
+			@body = body || proc{nil}
 			@icon = icon
 			@stylesheets = stylesheets
 			@imports = imports

--- a/lib/lively/page.rb
+++ b/lib/lively/page.rb
@@ -14,8 +14,8 @@ module Lively
 	#
 	# A page combines a renderable body with the stylesheets,
 	# import map, JavaScript modules, and body attributes required to present it.
-	# Pages are callable route handlers. The body is constructed for each request
-	# using a block.
+	# Pages are callable route handlers. Subclasses can override {#body} to construct
+	# content for each request.
 	class Page
 		TEMPLATE = XRB::Template.load_file(File.expand_path("page.xrb", __dir__))
 		
@@ -26,13 +26,8 @@ module Lively
 		# @parameter imports [Hash] JavaScript import map entries.
 		# @parameter modules [Array(String)] JavaScript module URLs in document order.
 		# @parameter body_attributes [Hash] Attributes applied to the body element.
-		# @yields {|request, parameters| ...} Constructs the document body for a request.
-		# 	@parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-		# 	@parameter parameters [Hash] The decoded query parameters.
-		# 	@returns [Object | Nil] The document body.
-		def initialize(title: "Lively", icon: nil, stylesheets: [], imports: {}, modules: [], body_attributes: {}, &body)
+		def initialize(title: "Lively", icon: nil, stylesheets: [], imports: {}, modules: [], body_attributes: {})
 			@title = title
-			@body = body || proc{nil}
 			@icon = icon
 			@stylesheets = stylesheets
 			@imports = imports
@@ -50,7 +45,7 @@ module Lively
 		# @parameter parameters [Hash] The decoded query parameters.
 		# @returns [Object | Nil] The body, which must respond to `to_html`.
 		def body(request = nil, parameters = {})
-			return @body.call(request, parameters)
+			return nil
 		end
 		
 		# @attribute [String | Nil] The favicon URL.

--- a/lib/lively/page.rb
+++ b/lib/lively/page.rb
@@ -12,17 +12,17 @@ require "xrb/template"
 module Lively
 	# Represents a complete HTML document.
 	#
-	# A page combines application content and live views with the stylesheets,
+	# A page combines a renderable body with the stylesheets,
 	# import map, JavaScript modules, and body attributes required to present it.
-	# Pages are callable route handlers. Subclasses can override {#views} to
-	# construct fresh live views for each request.
+	# Pages are callable route handlers. Subclasses can override {#body} to
+	# construct fresh content for each request.
 	class Page
 		TEMPLATE = XRB::Template.load_file(File.expand_path("page.xrb", __dir__))
 		
 		# Initialize a new page.
 		# @parameter title [String] The document title.
 		# @parameter resolver [Resolver | Nil] The resolver used to construct live views.
-		# @parameter body [Object | Nil] Static document body content rendered before any live views.
+		# @parameter body [Object | Nil] The document body. It must respond to `to_html`.
 		# @parameter icon [String | Nil] The favicon URL.
 		# @parameter stylesheets [Array(String | Hash)] Stylesheets in document order. Hash entries specify link attributes.
 		# @parameter imports [Hash] JavaScript import map entries.
@@ -47,8 +47,14 @@ module Lively
 		# @attribute [Resolver | Nil] The resolver used to construct live views.
 		attr :resolver
 		
-		# @attribute [Object | Nil] The document body.
-		attr :body
+		# The renderable document body. Subclasses can override this method to
+		# construct request-specific content.
+		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
+		# @parameter parameters [Hash] The decoded query parameters.
+		# @returns [Object | Nil] The body, which must respond to `to_html`.
+		def body(request = nil, parameters = {})
+			return @body
+		end
 		
 		# @attribute [String | Nil] The favicon URL.
 		attr :icon
@@ -67,26 +73,6 @@ module Lively
 		
 		# @attribute [XRB::Template] The document template.
 		attr :template
-		
-		# Construct a live view for the page.
-		# @parameter view_class [Class] The view class to construct.
-		# @parameter arguments [Hash] Additional keyword arguments for the view.
-		# @returns [Live::View] The constructed view.
-		# @raises [ArgumentError] If no resolver was provided or the view is not allowed.
-		def view(view_class, **arguments)
-			raise ArgumentError, "A resolver is required to construct views!" unless @resolver
-			
-			return @resolver.make(view_class, **arguments)
-		end
-		
-		# Construct the live views for a request. Subclasses can override this method
-		# to return zero or more views in document order.
-		# @returns [Array(Live::View)] The views in document order.
-		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-		# @parameter parameters [Hash] The decoded query parameters.
-		def views(request = nil, parameters = {})
-			return []
-		end
 		
 		# The opening body tag including configured attributes.
 		# @returns [XRB::Tag]
@@ -107,25 +93,14 @@ module Lively
 			XRB::Tag.closed("link", {rel: "stylesheet", type: "text/css"}.merge(attributes))
 		end
 		
-		# The rendered static body and live views.
+		# The rendered document body.
 		# @returns [Object]
 		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
 		# @parameter parameters [Hash] The decoded query parameters.
 		def body_content(request = nil, parameters = {})
 			return @rendered_body if @rendered_body
 			
-			views = self.views(request, parameters)
-			
-			XRB::Builder.fragment do |builder|
-				if @body
-					body = @body.respond_to?(:to_html) ? @body.to_html : @body
-					builder << body
-				end
-				
-				views.each do |view|
-					builder << view.to_html
-				end
-			end
+			return self.body(request, parameters)&.to_html || ""
 		end
 		
 		# The serialized JavaScript import map.

--- a/lib/lively/page.rb
+++ b/lib/lively/page.rb
@@ -14,8 +14,8 @@ module Lively
 	#
 	# A page combines application content and live views with the stylesheets,
 	# import map, JavaScript modules, and body attributes required to present it.
-	# Pages are callable route handlers. A page may be registered once with a
-	# router; its composition block constructs fresh live views for each request.
+	# Pages are callable route handlers. Subclasses can override {#views} to
+	# construct fresh live views for each request.
 	class Page
 		TEMPLATE = XRB::Template.load_file(File.expand_path("page.xrb", __dir__))
 		
@@ -28,9 +28,7 @@ module Lively
 		# @parameter imports [Hash] JavaScript import map entries.
 		# @parameter modules [Array(String)] JavaScript module URLs in document order.
 		# @parameter body_attributes [Hash] Attributes applied to the body element.
-		# @yields {|page| ...} Configures the live views composed by this page.
-		# 	@parameter page [Page] The page being configured.
-		def initialize(title: "Lively", resolver: nil, body: nil, icon: nil, stylesheets: [], imports: {}, modules: [], body_attributes: {}, &composition)
+		def initialize(title: "Lively", resolver: nil, body: nil, icon: nil, stylesheets: [], imports: {}, modules: [], body_attributes: {})
 			@title = title
 			@resolver = resolver
 			@body = body
@@ -40,8 +38,6 @@ module Lively
 			@modules = modules
 			@body_attributes = body_attributes
 			@template = TEMPLATE
-			@composition = composition
-			@views = nil
 			@rendered_body = nil
 		end
 		
@@ -72,33 +68,24 @@ module Lively
 		# @attribute [XRB::Template] The document template.
 		attr :template
 		
-		# Construct and append a live view to the page.
+		# Construct a live view for the page.
 		# @parameter view_class [Class] The view class to construct.
 		# @parameter arguments [Hash] Additional keyword arguments for the view.
 		# @returns [Live::View] The constructed view.
 		# @raises [ArgumentError] If no resolver was provided or the view is not allowed.
 		def view(view_class, **arguments)
 			raise ArgumentError, "A resolver is required to construct views!" unless @resolver
-			raise RuntimeError, "Views can only be constructed while composing a page!" unless @views
 			
-			view = @resolver.make(view_class, **arguments)
-			@views << view
-			
-			return view
+			return @resolver.make(view_class, **arguments)
 		end
 		
-		# The live views composed by this page.
+		# Construct the live views for a request. Subclasses can override this method
+		# to return zero or more views in document order.
 		# @returns [Array(Live::View)] The views in document order.
 		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
 		# @parameter parameters [Hash] The decoded query parameters.
 		def views(request = nil, parameters = {})
-			composition = self.dup
-			composition.instance_variable_set(:@views, [])
-			composition.instance_variable_set(:@composition, nil)
-			
-			@composition&.call(composition, request, parameters)
-			
-			return composition.instance_variable_get(:@views)
+			return []
 		end
 		
 		# The opening body tag including configured attributes.

--- a/lib/lively/page.rb
+++ b/lib/lively/page.rb
@@ -42,9 +42,8 @@ module Lively
 		
 		# Construct the renderable document body.
 		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-		# @parameter parameters [Hash] The decoded query parameters.
 		# @returns [Object | Nil] The body, which must respond to `to_html`.
-		def body(request = nil, parameters = {})
+		def body(request = nil)
 			return nil
 		end
 		
@@ -88,11 +87,10 @@ module Lively
 		# The rendered document body.
 		# @returns [Object]
 		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-		# @parameter parameters [Hash] The decoded query parameters.
-		def body_content(request = nil, parameters = {})
+		def body_content(request = nil)
 			return @rendered_body if @rendered_body
 			
-			return self.body(request, parameters)&.to_html || ""
+			return self.body(request)&.to_html || ""
 		end
 		
 		# The serialized JavaScript import map.
@@ -106,11 +104,10 @@ module Lively
 		
 		# Render this page to an HTML string.
 		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-		# @parameter parameters [Hash] The decoded query parameters.
 		# @returns [String]
-		def to_html(request = nil, parameters = {})
+		def to_html(request = nil)
 			rendering = self.dup
-			rendering.instance_variable_set(:@rendered_body, body_content(request, parameters))
+			rendering.instance_variable_set(:@rendered_body, body_content(request))
 			
 			@template.to_string(rendering)
 		end
@@ -118,9 +115,8 @@ module Lively
 		# Render this page as an HTTP response.
 		# @parameter request [Protocol::HTTP::Request] The incoming request.
 		# @returns [Protocol::HTTP::Response] A successful HTML response.
-		# @parameter parameters [Hash] The decoded query parameters.
-		def call(request, parameters = {})
-			Protocol::HTTP::Response[200, {"content-type" => "text/html; charset=utf-8"}, [to_html(request, parameters)]]
+		def call(request)
+			Protocol::HTTP::Response[200, {"content-type" => "text/html; charset=utf-8"}, [to_html(request)]]
 		end
 	end
 end

--- a/lib/lively/page.rb
+++ b/lib/lively/page.rb
@@ -14,31 +14,9 @@ module Lively
 	#
 	# A page combines a renderable body with the stylesheets, import map,
 	# JavaScript modules, and body attributes required to present it.
-	# Pages are callable route handlers.
+	# Pages render complete HTTP responses after a route has selected their content.
 	class Page
 		TEMPLATE = XRB::Template.load_file(File.expand_path("page.xrb", __dir__))
-		
-		# The per-request state used to render a page template.
-		class Context
-			# Initialize a rendering context.
-			# @parameter page [Page] The page being rendered.
-			# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-			# @parameter body [Object | Nil] The renderable document body.
-			def initialize(page, request, body)
-				@page = page
-				@request = request
-				@body = body
-			end
-			
-			# @attribute [Page] The page being rendered.
-			attr :page
-			
-			# @attribute [Protocol::HTTP::Request | Nil] The incoming request.
-			attr :request
-			
-			# @attribute [Object | Nil] The renderable document body.
-			attr :body
-		end
 		
 		# Initialize a new page.
 		# @parameter title [String] The document title.
@@ -112,17 +90,15 @@ module Lively
 		end
 		
 		# Render this page to an HTML string.
-		# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
 		# @returns [String]
-		def to_html(request = nil)
-			@template.to_string(Context.new(self, request, @body))
+		def to_html
+			@template.to_string(self)
 		end
 		
 		# Render this page as an HTTP response.
-		# @parameter request [Protocol::HTTP::Request] The incoming request.
 		# @returns [Protocol::HTTP::Response] A successful HTML response.
-		def call(request)
-			Protocol::HTTP::Response[200, {"content-type" => "text/html; charset=utf-8"}, [to_html(request)]]
+		def call
+			Protocol::HTTP::Response[200, {"content-type" => "text/html; charset=utf-8"}, [to_html]]
 		end
 	end
 end

--- a/lib/lively/page.xrb
+++ b/lib/lively/page.xrb
@@ -1,30 +1,31 @@
 <!DOCTYPE html>
+<?r page = self.page ?>
 <html>
 	<head>
-		<title>#{self.title}</title>
+		<title>#{page.title}</title>
 		
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		
-		<?r if self.icon ?>
-		<link rel="icon" type="image/png" href="#{self.icon}" />
+		<?r if page.icon ?>
+		<link rel="icon" type="image/png" href="#{page.icon}" />
 		<?r end ?>
-		<?r self.stylesheets.each do |stylesheet| ?>
-		#{self.stylesheet_tag(stylesheet)}
+		<?r page.stylesheets.each do |stylesheet| ?>
+		#{page.stylesheet_tag(stylesheet)}
 		<?r end ?>
 		
-		<?r unless self.imports.empty? ?>
+		<?r unless page.imports.empty? ?>
 		<script type="importmap">
-		#{self.import_map}
+		#{page.import_map}
 		</script>
 		<?r end ?>
 		
-		<?r self.modules.each do |source| ?>
+		<?r page.modules.each do |source| ?>
 		<script type="module" src="#{source}"></script>
 		<?r end ?>
 	</head>
 	
-	#{self.body_tag}
+	#{page.body_tag}
 		#{self.body_content}
 	</body>
 </html>

--- a/lib/lively/page.xrb
+++ b/lib/lively/page.xrb
@@ -1,31 +1,30 @@
 <!DOCTYPE html>
-<?r page = self.page ?>
 <html>
 	<head>
-		<title>#{page.title}</title>
+		<title>#{self.title}</title>
 		
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		
-		<?r if page.icon ?>
-		<link rel="icon" type="image/png" href="#{page.icon}" />
+		<?r if self.icon ?>
+		<link rel="icon" type="image/png" href="#{self.icon}" />
 		<?r end ?>
-		<?r page.stylesheets.each do |stylesheet| ?>
-		#{page.stylesheet_tag(stylesheet)}
+		<?r self.stylesheets.each do |stylesheet| ?>
+		#{self.stylesheet_tag(stylesheet)}
 		<?r end ?>
 		
-		<?r unless page.imports.empty? ?>
+		<?r unless self.imports.empty? ?>
 		<script type="importmap">
-		#{page.import_map}
+		#{self.import_map}
 		</script>
 		<?r end ?>
 		
-		<?r page.modules.each do |source| ?>
+		<?r self.modules.each do |source| ?>
 		<script type="module" src="#{source}"></script>
 		<?r end ?>
 	</head>
 	
-	#{page.body_tag}
+	#{self.body_tag}
 		#{self.body&.to_html}
 	</body>
 </html>

--- a/lib/lively/page.xrb
+++ b/lib/lively/page.xrb
@@ -26,6 +26,6 @@
 	</head>
 	
 	#{page.body_tag}
-		#{self.body_content}
+		#{self.body&.to_html}
 	</body>
 </html>

--- a/lib/lively/pages/index.rb
+++ b/lib/lively/pages/index.rb
@@ -29,20 +29,18 @@ module Lively
 			
 			# Initialize a new index page.
 			# @parameter title [String] The title of the page.
-			# @parameter body [Object | Nil] The document body. It must respond to `to_html`.
 			# @yields {|request, parameters| ...} Constructs the document body for a request.
 			# 	@parameter request [Protocol::HTTP::Request | Nil] The incoming request.
 			# 	@parameter parameters [Hash] The decoded query parameters.
 			# 	@returns [Object | Nil] The document body.
-			def initialize(title: "Lively", body: nil, &block)
+			def initialize(title: "Lively", &body)
 				super(
 					title: title,
-					body: body,
 					icon: ICON,
 					stylesheets: STYLESHEETS,
 					imports: IMPORTS,
 					modules: MODULES,
-					&block
+					&body
 				)
 			end
 		end

--- a/lib/lively/pages/index.rb
+++ b/lib/lively/pages/index.rb
@@ -34,14 +34,23 @@ module Lively
 			# 	@parameter parameters [Hash] The decoded query parameters.
 			# 	@returns [Object | Nil] The document body.
 			def initialize(title: "Lively", &body)
+				@body = body
+				
 				super(
 					title: title,
 					icon: ICON,
 					stylesheets: STYLESHEETS,
 					imports: IMPORTS,
-					modules: MODULES,
-					&body
+					modules: MODULES
 				)
+			end
+			
+			# Construct the renderable document body.
+			# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
+			# @parameter parameters [Hash] The decoded query parameters.
+			# @returns [Object | Nil] The body, which must respond to `to_html`.
+			def body(request = nil, parameters = {})
+				return @body&.call(request, parameters)
 			end
 		end
 	end

--- a/lib/lively/pages/index.rb
+++ b/lib/lively/pages/index.rb
@@ -28,12 +28,15 @@ module Lively
 			MODULES = ["/application.js"].freeze
 			
 			# Initialize a new index page.
+			# @parameter view_class [Class | Nil] The root live view class.
+			# @parameter view_arguments [Hash] Additional keyword arguments for the root view.
 			# @parameter title [String] The title of the page.
 			# @parameter resolver [Resolver | Nil] The resolver used to construct live views.
 			# @parameter body [Object | Nil] Static body content rendered before any live views.
-			# @yields {|page| ...} Configures the live views composed by this page.
-			# 	@parameter page [Page] The page being configured.
-			def initialize(title: "Lively", resolver: nil, body: nil, &block)
+			def initialize(view_class = nil, view_arguments: {}, title: "Lively", resolver: nil, body: nil)
+				@view_class = view_class
+				@view_arguments = view_arguments
+				
 				super(
 					title: title,
 					resolver: resolver,
@@ -41,9 +44,24 @@ module Lively
 					icon: ICON,
 					stylesheets: STYLESHEETS,
 					imports: IMPORTS,
-					modules: MODULES,
-					&block
+					modules: MODULES
 				)
+			end
+			
+			# @attribute [Class | Nil] The root live view class.
+			attr :view_class
+			
+			# @attribute [Hash] Additional keyword arguments for the root view.
+			attr :view_arguments
+			
+			# Construct the root live view for a request.
+			# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
+			# @parameter parameters [Hash] The decoded query parameters.
+			# @returns [Array(Live::View)] The root view, or an empty array when none was configured.
+			def views(request = nil, parameters = {})
+				return [] unless @view_class
+				
+				return [view(@view_class, **@view_arguments)]
 			end
 		end
 	end

--- a/lib/lively/pages/index.rb
+++ b/lib/lively/pages/index.rb
@@ -29,15 +29,20 @@ module Lively
 			
 			# Initialize a new index page.
 			# @parameter title [String] The title of the page.
-			# @parameter body [Object] The body content of the page.
-			def initialize(title: "Lively", body: nil)
+			# @parameter resolver [Resolver | Nil] The resolver used to construct live views.
+			# @parameter body [Object | Nil] Static body content rendered before any live views.
+			# @yields {|page| ...} Configures the live views composed by this page.
+			# 	@parameter page [Page] The page being configured.
+			def initialize(title: "Lively", resolver: nil, body: nil, &block)
 				super(
 					title: title,
+					resolver: resolver,
 					body: body,
 					icon: ICON,
 					stylesheets: STYLESHEETS,
 					imports: IMPORTS,
 					modules: MODULES,
+					&block
 				)
 			end
 		end

--- a/lib/lively/pages/index.rb
+++ b/lib/lively/pages/index.rb
@@ -29,10 +29,8 @@ module Lively
 			
 			# Initialize a new index page.
 			# @parameter title [String] The title of the page.
-			# @yields {|request| ...} Constructs the document body for a request.
-			# 	@parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-			# 	@returns [Object | Nil] The document body.
-			def initialize(title: "Lively", &body)
+			# @parameter body [Object | Nil] The renderable document body.
+			def initialize(title: "Lively", body: nil)
 				super(
 					title: title,
 					body: body,

--- a/lib/lively/pages/index.rb
+++ b/lib/lively/pages/index.rb
@@ -32,15 +32,13 @@ module Lively
 			# @parameter view_arguments [Hash] Additional keyword arguments for the root view.
 			# @parameter title [String] The title of the page.
 			# @parameter resolver [Resolver | Nil] The resolver used to construct live views.
-			# @parameter body [Object | Nil] Static body content rendered before any live views.
-			def initialize(view_class = nil, view_arguments: {}, title: "Lively", resolver: nil, body: nil)
+			def initialize(view_class = nil, view_arguments: {}, title: "Lively", resolver: nil)
 				@view_class = view_class
 				@view_arguments = view_arguments
 				
 				super(
 					title: title,
 					resolver: resolver,
-					body: body,
 					icon: ICON,
 					stylesheets: STYLESHEETS,
 					imports: IMPORTS,
@@ -54,14 +52,15 @@ module Lively
 			# @attribute [Hash] Additional keyword arguments for the root view.
 			attr :view_arguments
 			
-			# Construct the root live view for a request.
+			# Construct the root live view as the document body.
 			# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
 			# @parameter parameters [Hash] The decoded query parameters.
-			# @returns [Array(Live::View)] The root view, or an empty array when none was configured.
-			def views(request = nil, parameters = {})
-				return [] unless @view_class
+			# @returns [Live::View | Nil] The root view, if configured.
+			def body(request = nil, parameters = {})
+				return nil unless @view_class
+				raise ArgumentError, "A resolver is required to construct the root view!" unless @resolver
 				
-				return [view(@view_class, **@view_arguments)]
+				return @resolver.make(@view_class, **@view_arguments)
 			end
 		end
 	end

--- a/lib/lively/pages/index.rb
+++ b/lib/lively/pages/index.rb
@@ -33,22 +33,14 @@ module Lively
 			# 	@parameter request [Protocol::HTTP::Request | Nil] The incoming request.
 			# 	@returns [Object | Nil] The document body.
 			def initialize(title: "Lively", &body)
-				@body = body
-				
 				super(
 					title: title,
+					body: body,
 					icon: ICON,
 					stylesheets: STYLESHEETS,
 					imports: IMPORTS,
 					modules: MODULES
 				)
-			end
-			
-			# Construct the renderable document body.
-			# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-			# @returns [Object | Nil] The body, which must respond to `to_html`.
-			def body(request = nil)
-				return @body&.call(request)
 			end
 		end
 	end

--- a/lib/lively/pages/index.rb
+++ b/lib/lively/pages/index.rb
@@ -29,9 +29,8 @@ module Lively
 			
 			# Initialize a new index page.
 			# @parameter title [String] The title of the page.
-			# @yields {|request, parameters| ...} Constructs the document body for a request.
+			# @yields {|request| ...} Constructs the document body for a request.
 			# 	@parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-			# 	@parameter parameters [Hash] The decoded query parameters.
 			# 	@returns [Object | Nil] The document body.
 			def initialize(title: "Lively", &body)
 				@body = body
@@ -47,10 +46,9 @@ module Lively
 			
 			# Construct the renderable document body.
 			# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-			# @parameter parameters [Hash] The decoded query parameters.
 			# @returns [Object | Nil] The body, which must respond to `to_html`.
-			def body(request = nil, parameters = {})
-				return @body&.call(request, parameters)
+			def body(request = nil)
+				return @body&.call(request)
 			end
 		end
 	end

--- a/lib/lively/pages/index.rb
+++ b/lib/lively/pages/index.rb
@@ -28,39 +28,22 @@ module Lively
 			MODULES = ["/application.js"].freeze
 			
 			# Initialize a new index page.
-			# @parameter view_class [Class | Nil] The root live view class.
-			# @parameter view_arguments [Hash] Additional keyword arguments for the root view.
 			# @parameter title [String] The title of the page.
-			# @parameter resolver [Resolver | Nil] The resolver used to construct live views.
-			def initialize(view_class = nil, view_arguments: {}, title: "Lively", resolver: nil)
-				@view_class = view_class
-				@view_arguments = view_arguments
-				
+			# @parameter body [Object | Nil] The document body. It must respond to `to_html`.
+			# @yields {|request, parameters| ...} Constructs the document body for a request.
+			# 	@parameter request [Protocol::HTTP::Request | Nil] The incoming request.
+			# 	@parameter parameters [Hash] The decoded query parameters.
+			# 	@returns [Object | Nil] The document body.
+			def initialize(title: "Lively", body: nil, &block)
 				super(
 					title: title,
-					resolver: resolver,
+					body: body,
 					icon: ICON,
 					stylesheets: STYLESHEETS,
 					imports: IMPORTS,
-					modules: MODULES
+					modules: MODULES,
+					&block
 				)
-			end
-			
-			# @attribute [Class | Nil] The root live view class.
-			attr :view_class
-			
-			# @attribute [Hash] Additional keyword arguments for the root view.
-			attr :view_arguments
-			
-			# Construct the root live view as the document body.
-			# @parameter request [Protocol::HTTP::Request | Nil] The incoming request.
-			# @parameter parameters [Hash] The decoded query parameters.
-			# @returns [Live::View | Nil] The root view, if configured.
-			def body(request = nil, parameters = {})
-				return nil unless @view_class
-				raise ArgumentError, "A resolver is required to construct the root view!" unless @resolver
-				
-				return @resolver.make(@view_class, **@view_arguments)
 			end
 		end
 	end

--- a/lib/lively/resolver.rb
+++ b/lib/lively/resolver.rb
@@ -25,15 +25,14 @@ module Lively
 		# @parameter view_class [Class] The view class to construct.
 		# @parameter id [String] The unique identifier for the view.
 		# @parameter data [Hash] The data associated with the view.
-		# @parameter arguments [Hash] Additional keyword arguments for the view.
 		# @returns [Live::View] A new view instance.
 		# @raises [ArgumentError] If the view class is not allowed.
-		def make(view_class, id: view_class.unique_id, data: {}, **arguments)
+		def make(view_class, id: view_class.unique_id, data: {})
 			unless @allowed[view_class.name].equal?(view_class)
 				raise ArgumentError, "View class is not allowed: #{view_class}!"
 			end
 			
-			view_class.new(id, data, **@state, **arguments)
+			view_class.new(id, data, **@state)
 		end
 		
 		# Resolve a client-side element to a server-side instance with shared state.

--- a/lib/lively/resolver.rb
+++ b/lib/lively/resolver.rb
@@ -21,13 +21,28 @@ module Lively
 		# @attribute [Hash] The shared state passed to view constructors.
 		attr :state
 		
+		# Construct an allowed view with shared state.
+		# @parameter view_class [Class] The view class to construct.
+		# @parameter id [String] The unique identifier for the view.
+		# @parameter data [Hash] The data associated with the view.
+		# @parameter arguments [Hash] Additional keyword arguments for the view.
+		# @returns [Live::View] A new view instance.
+		# @raises [ArgumentError] If the view class is not allowed.
+		def make(view_class, id: view_class.unique_id, data: {}, **arguments)
+			unless @allowed[view_class.name].equal?(view_class)
+				raise ArgumentError, "View class is not allowed: #{view_class}!"
+			end
+			
+			view_class.new(id, data, **@state, **arguments)
+		end
+		
 		# Resolve a client-side element to a server-side instance with shared state.
 		# @parameter id [String] The unique element identifier.
 		# @parameter data [Hash] The element data attributes.
 		# @returns [Live::Element | Nil] The resolved element, or `nil`.
 		def call(id, data)
 			if klass = @allowed[data[:class]]
-				return klass.new(id, data, **@state)
+				return self.make(klass, id: id, data: data)
 			end
 		end
 	end

--- a/lib/lively/resolver.rb
+++ b/lib/lively/resolver.rb
@@ -21,28 +21,11 @@ module Lively
 		# @attribute [Hash] The shared state passed to view constructors.
 		attr :state
 		
-		# Construct an allowed view with shared state.
-		# @parameter view_class [Class] The view class to construct.
-		# @parameter id [String] The unique identifier for the view.
-		# @parameter data [Hash] The data associated with the view.
-		# @returns [Live::View] A new view instance.
-		# @raises [ArgumentError] If the view class is not allowed.
-		def make(view_class, id: view_class.unique_id, data: {})
-			unless @allowed[view_class.name].equal?(view_class)
-				raise ArgumentError, "View class is not allowed: #{view_class}!"
-			end
-			
-			view_class.new(id, data, **@state)
-		end
+		private
 		
-		# Resolve a client-side element to a server-side instance with shared state.
-		# @parameter id [String] The unique element identifier.
-		# @parameter data [Hash] The element data attributes.
-		# @returns [Live::Element | Nil] The resolved element, or `nil`.
-		def call(id, data)
-			if klass = @allowed[data[:class]]
-				return self.make(klass, id: id, data: data)
-			end
+		# Construct a view with shared application state.
+		def make(view_class, id, data, **options)
+			super(view_class, id, data, **@state, **options)
 		end
 	end
 end

--- a/lib/lively/router.rb
+++ b/lib/lively/router.rb
@@ -10,11 +10,10 @@ module Lively
 	# Dispatches HTTP requests to handlers using exact path and method matches.
 	#
 	# Request targets are parsed with {Protocol::URL::Reference}. Handlers receive
-	# the original request and the decoded query parameters.
+	# the original request.
 	class Router < Protocol::HTTP::Middleware
-		EMPTY_PARAMETERS = {}.freeze
 		ANY_METHOD = nil
-		private_constant :EMPTY_PARAMETERS, :ANY_METHOD
+		private_constant :ANY_METHOD
 		
 		# Builds an immutable route table.
 		class Builder
@@ -39,9 +38,8 @@ module Lively
 			# @parameter path [String] The absolute path to match.
 			# @parameter handler [Interface(:call) | Nil] A callable route handler.
 			# @parameter methods [String | Symbol | Array(String | Symbol) | Nil] The accepted HTTP methods.
-			# @yields {|request, parameters| ...} The route handler.
+			# @yields {|request| ...} The route handler.
 			# 	@parameter request [Protocol::HTTP::Request] The original request.
-			# 	@parameter parameters [Hash] The decoded query parameters.
 			# @returns [Builder] The builder.
 			def route(path, handler = nil, methods: nil, &block)
 				raise ArgumentError, "Provide a route handler or block, not both!" if handler && block
@@ -66,7 +64,7 @@ module Lively
 			Protocol::HTTP::Methods.each do |name, method|
 				# Add a route for this HTTP method.
 				# @parameter path [String] The absolute path to match.
-				# @yields {|request, parameters| ...} The route handler.
+				# @yields {|request| ...} The route handler.
 				# @returns [Builder] The builder.
 				define_method(name) do |path, handler = nil, &block|
 					route(path, handler, methods: method, &block)
@@ -143,10 +141,7 @@ module Lively
 				return Protocol::HTTP::Response[405, [["allow", allowed_methods]]]
 			end
 			
-			parameters = parse_query(reference)
-			return Protocol::HTTP::Response[400] unless parameters
-			
-			return handler.call(request, parameters)
+			return handler.call(request)
 		end
 		
 		private
@@ -160,10 +155,5 @@ module Lively
 			nil
 		end
 		
-		def parse_query(reference)
-			reference.parse_query! || EMPTY_PARAMETERS
-		rescue ArgumentError
-			nil
-		end
 	end
 end

--- a/lib/lively/router.rb
+++ b/lib/lively/router.rb
@@ -30,12 +30,15 @@ module Lively
 		# it may be a single method or an array of methods.
 		#
 		# @parameter path [String] The absolute path to match.
+		# @parameter handler [Interface(:call) | Nil] A callable route handler.
 		# @parameter methods [String | Symbol | Array(String | Symbol) | Nil] The accepted HTTP methods.
 		# @yields {|request, parameters| ...} The route handler.
 		# 	@parameter request [Protocol::HTTP::Request] The original request.
 		# 	@parameter parameters [Hash] The decoded query parameters.
 		# @returns [Router] The router.
-		def route(path, methods: nil, &handler)
+		def route(path, handler = nil, methods: nil, &block)
+			raise ArgumentError, "Provide a route handler or block, not both!" if handler && block
+			handler ||= block
 			raise ArgumentError, "A route handler is required!" unless handler
 			
 			path = route_path(path)
@@ -58,8 +61,8 @@ module Lively
 			# @parameter path [String] The absolute path to match.
 			# @yields {|request, parameters| ...} The route handler.
 			# @returns [Router] The router.
-			define_method(name) do |path, &handler|
-				route(path, methods: method, &handler)
+			define_method(name) do |path, handler = nil, &block|
+				route(path, handler, methods: method, &block)
 			end
 		end
 		

--- a/lib/lively/router.rb
+++ b/lib/lively/router.rb
@@ -3,7 +3,7 @@
 # Released under the MIT License.
 # Copyright, 2026, by Samuel Williams.
 
-require "protocol/http"
+require "protocol/http/middleware"
 require "protocol/url"
 
 module Lively
@@ -11,71 +11,132 @@ module Lively
 	#
 	# Request targets are parsed with {Protocol::URL::Reference}. Handlers receive
 	# the original request and the decoded query parameters.
-	class Router
+	class Router < Protocol::HTTP::Middleware
 		EMPTY_PARAMETERS = {}.freeze
 		ANY_METHOD = nil
 		private_constant :EMPTY_PARAMETERS, :ANY_METHOD
 		
-		# Initialize a router.
-		# @yields {|router| ...} The router to configure.
-		def initialize
-			@routes = {}
+		# Builds an immutable route table.
+		class Builder
+			# Initialize a route builder.
+			def initialize
+				@routes = {}
+			end
 			
-			yield self if block_given?
-		end
-		
-		# Add a route.
-		#
-		# When `methods` is omitted, the handler accepts every HTTP method. Otherwise,
-		# it may be a single method or an array of methods.
-		#
-		# @parameter path [String] The absolute path to match.
-		# @parameter handler [Interface(:call) | Nil] A callable route handler.
-		# @parameter methods [String | Symbol | Array(String | Symbol) | Nil] The accepted HTTP methods.
-		# @yields {|request, parameters| ...} The route handler.
-		# 	@parameter request [Protocol::HTTP::Request] The original request.
-		# 	@parameter parameters [Hash] The decoded query parameters.
-		# @returns [Router] The router.
-		def route(path, handler = nil, methods: nil, &block)
-			raise ArgumentError, "Provide a route handler or block, not both!" if handler && block
-			handler ||= block
-			raise ArgumentError, "A route handler is required!" unless handler
+			# A frozen snapshot of the configured routes.
+			# @returns [Hash] The route table.
+			def routes
+				@routes.transform_values do |handlers|
+					handlers.dup.freeze
+				end.freeze
+			end
 			
-			path = route_path(path)
-			methods = route_methods(methods)
-			handlers = (@routes[path] ||= {})
-			
-			methods.each do |method|
-				if handlers.key?(method)
-					raise ArgumentError, "Route already defined for #{method || "any method"} #{path}!"
+			# Add a route.
+			#
+			# When `methods` is omitted, the handler accepts every HTTP method. Otherwise,
+			# it may be a single method or an array of methods.
+			#
+			# @parameter path [String] The absolute path to match.
+			# @parameter handler [Interface(:call) | Nil] A callable route handler.
+			# @parameter methods [String | Symbol | Array(String | Symbol) | Nil] The accepted HTTP methods.
+			# @yields {|request, parameters| ...} The route handler.
+			# 	@parameter request [Protocol::HTTP::Request] The original request.
+			# 	@parameter parameters [Hash] The decoded query parameters.
+			# @returns [Builder] The builder.
+			def route(path, handler = nil, methods: nil, &block)
+				raise ArgumentError, "Provide a route handler or block, not both!" if handler && block
+				handler ||= block
+				raise ArgumentError, "A route handler is required!" unless handler
+				
+				path = route_path(path)
+				methods = route_methods(methods)
+				handlers = (@routes[path] ||= {})
+				
+				methods.each do |method|
+					if handlers.key?(method)
+						raise ArgumentError, "Route already defined for #{method || "any method"} #{path}!"
+					end
+					
+					handlers[method] = handler
 				end
 				
-				handlers[method] = handler
+				return self
 			end
 			
-			return self
+			Protocol::HTTP::Methods.each do |name, method|
+				# Add a route for this HTTP method.
+				# @parameter path [String] The absolute path to match.
+				# @yields {|request, parameters| ...} The route handler.
+				# @returns [Builder] The builder.
+				define_method(name) do |path, handler = nil, &block|
+					route(path, handler, methods: method, &block)
+				end
+			end
+			
+			private
+			
+			def route_path(path)
+				url = Protocol::URL[path]
+				
+				unless url && !url.is_a?(Protocol::URL::Absolute)
+					raise ArgumentError, "Route must be an absolute path: #{path.inspect}!"
+				end
+				
+				reference = Protocol::URL::Reference[url]
+				
+				unless reference.path.absolute?
+					raise ArgumentError, "Route must be an absolute path: #{path.inspect}!"
+				end
+				
+				if reference.query? || reference.fragment?
+					raise ArgumentError, "Route path cannot include a query or fragment: #{path.inspect}!"
+				end
+				
+				return reference.path.freeze
+			end
+			
+			def route_methods(methods)
+				return [ANY_METHOD] unless methods
+				
+				methods = Array(methods)
+				raise ArgumentError, "At least one HTTP method is required!" if methods.empty?
+				
+				return methods.map do |method|
+					raise ArgumentError, "HTTP method cannot be nil!" unless method
+					
+					method.to_s.upcase
+				end.uniq
+			end
 		end
 		
-		Protocol::HTTP::Methods.each do |name, method|
-			# Add a route for this HTTP method.
-			# @parameter path [String] The absolute path to match.
-			# @yields {|request, parameters| ...} The route handler.
-			# @returns [Router] The router.
-			define_method(name) do |path, handler = nil, &block|
-				route(path, handler, methods: method, &block)
-			end
+		# Build and configure a frozen router.
+		# @parameter delegate [Protocol::HTTP::Middleware] The middleware for unmatched requests.
+		# @yields {|builder| ...} Configures the routes.
+		# 	@parameter builder [Builder] The route builder.
+		# @returns [Router] The configured router.
+		def self.build(delegate = Protocol::HTTP::Middleware::NotFound)
+			builder = Builder.new
+			yield builder
+			
+			return new(delegate, builder.routes).freeze
+		end
+		
+		# Initialize a router.
+		# @parameter delegate [Protocol::HTTP::Middleware] The middleware for unmatched requests.
+		# @parameter routes [Hash] The frozen route table.
+		def initialize(delegate, routes)
+			super(delegate)
+			@routes = routes
 		end
 		
 		# Dispatch a request to a matching route.
 		# @parameter request [Protocol::HTTP::Request] The request to dispatch.
-		# @returns [Protocol::HTTP::Response | Nil] The handler or error response, or `nil` when no path matches.
+		# @returns [Protocol::HTTP::Response] The handler, error, or delegate response.
 		def call(request)
 			reference = parse_reference(request.path)
 			return Protocol::HTTP::Response[400] unless reference
 			
-			unless handlers = @routes[reference.path]
-				return nil
-			end
+			return super unless handlers = @routes[reference.path]
 			
 			unless handler = handlers[request.method] || handlers[ANY_METHOD]
 				allowed_methods = handlers.keys.compact.sort.join(", ")
@@ -89,39 +150,6 @@ module Lively
 		end
 		
 		private
-		
-		def route_path(path)
-			url = Protocol::URL[path]
-			
-			unless url && !url.is_a?(Protocol::URL::Absolute)
-				raise ArgumentError, "Route must be an absolute path: #{path.inspect}!"
-			end
-			
-			reference = Protocol::URL::Reference[url]
-			
-			unless reference.path.absolute?
-				raise ArgumentError, "Route must be an absolute path: #{path.inspect}!"
-			end
-			
-			if reference.query? || reference.fragment?
-				raise ArgumentError, "Route path cannot include a query or fragment: #{path.inspect}!"
-			end
-			
-			return reference.path.freeze
-		end
-		
-		def route_methods(methods)
-			return [ANY_METHOD] unless methods
-			
-			methods = Array(methods)
-			raise ArgumentError, "At least one HTTP method is required!" if methods.empty?
-			
-			return methods.map do |method|
-				raise ArgumentError, "HTTP method cannot be nil!" unless method
-				
-				method.to_s.upcase
-			end.uniq
-		end
 		
 		def parse_reference(path)
 			reference = Protocol::URL::Reference[path]

--- a/lib/lively/router.rb
+++ b/lib/lively/router.rb
@@ -151,8 +151,6 @@ module Lively
 			return if reference&.fragment?
 			
 			return reference
-		rescue ArgumentError
-			nil
 		end
 		
 	end

--- a/lively.gemspec
+++ b/lively.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "falcon", "~> 0.47"
 	spec.add_dependency "io-watch"
 	spec.add_dependency "live", "~> 0.18"
-	spec.add_dependency "protocol-url", "~> 0.18"
+	spec.add_dependency "protocol-url", "~> 0.19"
 	spec.add_dependency "xrb"
 end

--- a/lively.gemspec
+++ b/lively.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "async-service", "~> 0.23"
 	spec.add_dependency "falcon", "~> 0.47"
 	spec.add_dependency "io-watch"
-	spec.add_dependency "live", "~> 0.18"
+	spec.add_dependency "live", "~> 0.19"
 	spec.add_dependency "protocol-url", "~> 0.19"
 	spec.add_dependency "xrb"
 end

--- a/test/lively/application.rb
+++ b/test/lively/application.rb
@@ -40,7 +40,7 @@ describe Lively::Application do
 		
 		it "renders the custom view at the root route with shared state" do
 			tag_class = Class.new(Live::View) do
-				def initialize(id = self.class.unique_id, data = {}, message:)
+				def initialize(id, data, message:)
 					super(id, data)
 					@message = message
 				end
@@ -172,9 +172,9 @@ describe Lively::Application do
 		it "constructs the root view only when its route is requested" do
 			resolved = []
 			resolver = Object.new
-			resolver.define_singleton_method(:make) do |view_class|
+			resolver.define_singleton_method(:root) do |view_class|
 				resolved << view_class
-				view_class.new
+				view_class.root
 			end
 			
 			application_class = Class.new(Lively::Application) do
@@ -229,7 +229,7 @@ describe Lively::Application do
 				
 				define_method(:configure_routes) do |router|
 					router.get("/") do
-						body = resolver.make(root_view)
+						body = resolver.root(root_view)
 						Lively::Pages::Index.new(title: title, body: body).call
 					end
 				end
@@ -255,7 +255,7 @@ describe Lively::Application do
 			application_class = Class.new(Lively::Application) do
 				def configure_routes(router)
 					router.get("/") do
-						body = resolver.make(Lively::HelloWorld)
+						body = resolver.root(Lively::HelloWorld)
 						Lively::Pages::Index.new(title: title, body: body).call
 					end
 				end

--- a/test/lively/application.rb
+++ b/test/lively/application.rb
@@ -169,6 +169,26 @@ describe Lively::Application do
 			expect(application.router).to be_equal(application.router)
 		end
 		
+		it "constructs the root view only when its route is requested" do
+			resolved = []
+			resolver = Object.new
+			resolver.define_singleton_method(:make) do |view_class|
+				resolved << view_class
+				view_class.new
+			end
+			
+			application_class = Class.new(Lively::Application) do
+				define_method(:resolver) {resolver}
+			end
+			application = application_class.new(delegate)
+			
+			application.router
+			expect(resolved).to be(:empty?)
+			
+			application.call(Protocol::HTTP::Request.new("http", "localhost", "GET", "/"))
+			expect(resolved).to be == [Lively::HelloWorld]
+		end
+		
 		it "routes the default view explicitly" do
 			response = application.router.call(Protocol::HTTP::Request.new("http", "localhost", "GET", "/"))
 			html = response.read
@@ -208,11 +228,10 @@ describe Lively::Application do
 				define_method(:allowed_views) {[other_view, root_view]}
 				
 				define_method(:configure_routes) do |router|
-					page = Lively::Pages::Index.new(title: title) do
-						resolver.make(root_view)
+					router.get("/") do |request|
+						body = resolver.make(root_view)
+						Lively::Pages::Index.new(title: title, body: body).call(request)
 					end
-					
-					router.get("/", page)
 				end
 			end
 			
@@ -235,11 +254,10 @@ describe Lively::Application do
 		it "preserves system routes when application routes are replaced" do
 			application_class = Class.new(Lively::Application) do
 				def configure_routes(router)
-					page = Lively::Pages::Index.new(title: title) do
-						resolver.make(Lively::HelloWorld)
+					router.get("/") do |request|
+						body = resolver.make(Lively::HelloWorld)
+						Lively::Pages::Index.new(title: title, body: body).call(request)
 					end
-					
-					router.get("/", page)
 				end
 			end
 			

--- a/test/lively/application.rb
+++ b/test/lively/application.rb
@@ -164,63 +164,6 @@ describe Lively::Application do
 		end
 	end
 	
-	with "#make_view" do
-		it "constructs a view with shared state and route arguments" do
-			view_class = Class.new(Live::View) do
-				def initialize(id = self.class.unique_id, data = {}, message:, prefix:)
-					super(id, data)
-					@text = "#{prefix}: #{message}"
-				end
-				
-				attr :text
-			end
-			
-			application_class = Class.new(Lively::Application) do
-				define_method(:state) {{prefix: "Shared"}}
-			end
-			
-			view = application_class.new(delegate).make_view(view_class, message: "Hello")
-			
-			expect(view.text).to be == "Shared: Hello"
-		end
-	end
-	
-	with "#make_page" do
-		it "constructs the default page around a view" do
-			view = Lively::HelloWorld.new
-			page = application.make_page(view)
-			
-			expect(page).to be_a(Lively::Pages::Index)
-			expect(page.title).to be == application.title
-			expect(page.body).to be == view
-		end
-	end
-	
-	with "#render_view" do
-		it "renders a view as an HTTP response" do
-			request = Protocol::HTTP::Request["GET", "/"]
-			response = application.render_view(request, Lively::HelloWorld)
-			
-			expect(response.status).to be == 200
-			expect(response.read).to be(:include?, "Hello, I'm Lively!")
-		end
-		
-		it "uses the application page" do
-			application_class = Class.new(Lively::Application) do
-				private
-				
-				def make_page(view)
-					Lively::Pages::Index.new(title: "Custom Page", body: view)
-				end
-			end
-			
-			request = Protocol::HTTP::Request["GET", "/"]
-			response = application_class.new(delegate).render_view(request, Lively::HelloWorld)
-			
-			expect(response.read).to be(:include?, "<title>Custom Page</title>")
-		end
-	end
-	
 	with "#handle" do
 		it "delegates unmatched requests" do
 			response = application.handle(Protocol::HTTP::Request.new("http", "localhost", "GET", "/unknown"))
@@ -275,9 +218,11 @@ describe Lively::Application do
 				define_method(:allowed_views) {[other_view, root_view]}
 				
 				define_method(:configure_routes) do |router|
-					router.get("/") do |request|
-						render_view(request, root_view)
+					page = Lively::Pages::Index.new(title: title, resolver: resolver) do |page|
+						page.view(root_view)
 					end
+					
+					router.get("/", page)
 				end
 			end
 			
@@ -292,9 +237,11 @@ describe Lively::Application do
 		it "preserves system routes when application routes are replaced" do
 			application_class = Class.new(Lively::Application) do
 				def configure_routes(router)
-					router.get("/") do |request|
-						render_view(request, Lively::HelloWorld)
+					page = Lively::Pages::Index.new(title: title, resolver: resolver) do |page|
+						page.view(Lively::HelloWorld)
 					end
+					
+					router.get("/", page)
 				end
 			end
 			

--- a/test/lively/application.rb
+++ b/test/lively/application.rb
@@ -164,16 +164,6 @@ describe Lively::Application do
 		end
 	end
 	
-	with "#handle" do
-		it "delegates unmatched requests" do
-			response = application.handle(Protocol::HTTP::Request.new("http", "localhost", "GET", "/unknown"))
-			
-			expect(response).to be_a(Protocol::HTTP::Response)
-			expect(response.status).to be == 404
-			expect(response.read).to be == "Not Found"
-		end
-	end
-	
 	with "#router" do
 		it "is memoized" do
 			expect(application.router).to be_equal(application.router)
@@ -234,6 +224,14 @@ describe Lively::Application do
 	end
 	
 	with "#call" do
+		it "delegates unmatched requests" do
+			response = application.call(Protocol::HTTP::Request.new("http", "localhost", "GET", "/unknown"))
+			
+			expect(response).to be_a(Protocol::HTTP::Response)
+			expect(response.status).to be == 404
+			expect(response.read).to be == "Not Found"
+		end
+		
 		it "preserves system routes when application routes are replaced" do
 			application_class = Class.new(Lively::Application) do
 				def configure_routes(router)

--- a/test/lively/application.rb
+++ b/test/lively/application.rb
@@ -228,9 +228,9 @@ describe Lively::Application do
 				define_method(:allowed_views) {[other_view, root_view]}
 				
 				define_method(:configure_routes) do |router|
-					router.get("/") do |request|
+					router.get("/") do
 						body = resolver.make(root_view)
-						Lively::Pages::Index.new(title: title, body: body).call(request)
+						Lively::Pages::Index.new(title: title, body: body).call
 					end
 				end
 			end
@@ -254,9 +254,9 @@ describe Lively::Application do
 		it "preserves system routes when application routes are replaced" do
 			application_class = Class.new(Lively::Application) do
 				def configure_routes(router)
-					router.get("/") do |request|
+					router.get("/") do
 						body = resolver.make(Lively::HelloWorld)
-						Lively::Pages::Index.new(title: title, body: body).call(request)
+						Lively::Pages::Index.new(title: title, body: body).call
 					end
 				end
 			end

--- a/test/lively/application.rb
+++ b/test/lively/application.rb
@@ -218,9 +218,7 @@ describe Lively::Application do
 				define_method(:allowed_views) {[other_view, root_view]}
 				
 				define_method(:configure_routes) do |router|
-					page = Lively::Pages::Index.new(title: title, resolver: resolver) do |page|
-						page.view(root_view)
-					end
+					page = Lively::Pages::Index.new(root_view, title: title, resolver: resolver)
 					
 					router.get("/", page)
 				end
@@ -237,9 +235,7 @@ describe Lively::Application do
 		it "preserves system routes when application routes are replaced" do
 			application_class = Class.new(Lively::Application) do
 				def configure_routes(router)
-					page = Lively::Pages::Index.new(title: title, resolver: resolver) do |page|
-						page.view(Lively::HelloWorld)
-					end
+					page = Lively::Pages::Index.new(Lively::HelloWorld, title: title, resolver: resolver)
 					
 					router.get("/", page)
 				end

--- a/test/lively/application.rb
+++ b/test/lively/application.rb
@@ -218,7 +218,9 @@ describe Lively::Application do
 				define_method(:allowed_views) {[other_view, root_view]}
 				
 				define_method(:configure_routes) do |router|
-					page = Lively::Pages::Index.new(root_view, title: title, resolver: resolver)
+					page = Lively::Pages::Index.new(title: title) do
+						resolver.make(root_view)
+					end
 					
 					router.get("/", page)
 				end
@@ -235,7 +237,9 @@ describe Lively::Application do
 		it "preserves system routes when application routes are replaced" do
 			application_class = Class.new(Lively::Application) do
 				def configure_routes(router)
-					page = Lively::Pages::Index.new(Lively::HelloWorld, title: title, resolver: resolver)
+					page = Lively::Pages::Index.new(title: title) do
+						resolver.make(Lively::HelloWorld)
+					end
 					
 					router.get("/", page)
 				end

--- a/test/lively/application.rb
+++ b/test/lively/application.rb
@@ -183,8 +183,8 @@ describe Lively::Application do
 				def configure_routes(router)
 					super
 					
-					router.get("/example") do |_request, parameters|
-						Protocol::HTTP::Response[200, [], [parameters.fetch("message")]]
+					router.get("/example") do |request|
+						Protocol::HTTP::Response[200, [], [request.path]]
 					end
 				end
 			end
@@ -193,7 +193,7 @@ describe Lively::Application do
 			response = application.call(Protocol::HTTP::Request.new("http", "localhost", "GET", "/example?message=Hello"))
 			
 			expect(response.status).to be == 200
-			expect(response.read).to be == "Hello"
+			expect(response.read).to be == "/example?message=Hello"
 		end
 		
 		it "allows the root view to be selected by its route" do

--- a/test/lively/environment/application.rb
+++ b/test/lively/environment/application.rb
@@ -72,8 +72,22 @@ describe Lively::Environment::Application do
 	end
 	
 	with "middleware configuration" do
+		it "uses the current directory as its default root" do
+			instance = Object.new.extend(Lively::Environment::Middleware)
+			
+			expect(instance.root).to be == Dir.pwd
+		end
+		
 		it "provides a middleware stack" do
 			expect(evaluator.middleware).to be_a(Protocol::HTTP::Middleware)
+		end
+	end
+	
+	with "service construction" do
+		it "constructs the selected transport service" do
+			service = evaluator.make_service(environment)
+			
+			expect(service).to be_a(Falcon::Service::Server)
 		end
 	end
 end

--- a/test/lively/hello_world.rb
+++ b/test/lively/hello_world.rb
@@ -35,7 +35,7 @@ describe Lively::HelloWorld do
 	include Sus::Fixtures::Async
 	include Sus::Fixtures::Console
 	
-	let(:hello_world) {Lively::HelloWorld.new}
+	let(:hello_world) {Lively::HelloWorld.root}
 	
 	with "#initialize" do
 		it "creates a new HelloWorld instance" do
@@ -147,8 +147,8 @@ describe Lively::HelloWorld do
 			
 			code_example = builder.content.find{|c| c.include?("#!/usr/bin/env lively")}
 			expect(code_example).not.to be_nil
-			expect(code_example.include?("class Application")).to be == true
-			expect(code_example.include?("Lively::HelloWorld.new")).to be == true
+			expect(code_example.include?("Application =")).to be == true
+			expect(code_example.include?("Lively::Application[Lively::HelloWorld]")).to be == true
 		end
 		
 		it "includes examples directory reference" do

--- a/test/lively/page.rb
+++ b/test/lively/page.rb
@@ -8,7 +8,7 @@ require "protocol/http/request"
 
 describe Lively::Page do
 	with "#initialize" do
-		it "accepts document content and assets" do
+		it "accepts document assets" do
 			page = subject.new(
 				title: "Example",
 				icon: "/icon.png",
@@ -16,12 +16,10 @@ describe Lively::Page do
 				imports: {"example" => "/example.js"},
 				modules: ["/application.js"],
 				body_attributes: {class: "example"}
-			) do
-				"Body"
-			end
+			)
 			
 			expect(page.title).to be == "Example"
-			expect(page.body).to be == "Body"
+			expect(page.body).to be_nil
 			expect(page.icon).to be == "/icon.png"
 			expect(page.stylesheets).to be == [{href: "/site.css", media: "screen"}]
 			expect(page.imports).to be == {"example" => "/example.js"}
@@ -30,14 +28,6 @@ describe Lively::Page do
 			expect(page.template).to be_a(XRB::Template)
 		end
 		
-		it "accepts a request-aware body block" do
-			request = Protocol::HTTP::Request["GET", "/"]
-			page = subject.new do |request, parameters|
-				"#{request.method}:#{parameters.fetch("message")}"
-			end
-			
-			expect(page.body(request, {"message" => "Hello"})).to be == "GET:Hello"
-		end
 	end
 	
 	with "#to_html" do
@@ -51,9 +41,12 @@ describe Lively::Page do
 					@content
 				end
 			end
-			page = subject.new do |request, parameters|
-				body_class.new("#{request.method}:#{parameters.fetch("message")}")
+			page_class = Class.new(subject) do
+				define_method(:body) do |request, parameters|
+					body_class.new("#{request.method}:#{parameters.fetch("message")}")
+				end
 			end
+			page = page_class.new
 			request = Protocol::HTTP::Request["GET", "/"]
 			
 			html = page.to_html(request, {"message" => "Hello"})
@@ -67,7 +60,12 @@ describe Lively::Page do
 				XRB::MarkupString.raw("<main>Example</main>")
 			end
 			
-			page = subject.new(
+			page_class = Class.new(subject) do
+				define_method(:body) do |_request = nil, _parameters = {}|
+					body
+				end
+			end
+			page = page_class.new(
 				title: "Example",
 				icon: "/icon.png",
 				stylesheets: ["/site.css", {href: "/theme.css", media: "print"}],
@@ -77,9 +75,7 @@ describe Lively::Page do
 					class: "playback",
 					data: {autoplay: "true", controls: "false"},
 				}
-			) do
-				body
-			end
+			)
 			
 			html = page.to_html
 			
@@ -120,13 +116,16 @@ describe Lively::Page do
 				"<main>Example</main>"
 			end
 			
-			page = subject.new(
+			page_class = Class.new(subject) do
+				define_method(:body) do |_request = nil, _parameters = {}|
+					body
+				end
+			end
+			page = page_class.new(
 				title: "<Example>",
 				stylesheets: ["/site.css?one=1&two=2"],
 				body_attributes: {title: 'one & "two"'}
-			) do
-				body
-			end
+			)
 			
 			html = page.to_html
 			

--- a/test/lively/page.rb
+++ b/test/lively/page.rb
@@ -4,7 +4,6 @@
 # Copyright, 2026, by Samuel Williams.
 
 require "lively/page"
-require "lively/resolver"
 require "protocol/http/request"
 
 describe Lively::Page do
@@ -29,31 +28,37 @@ describe Lively::Page do
 			expect(page.body_attributes).to be == {class: "example"}
 			expect(page.template).to be_a(XRB::Template)
 		end
+		
+		it "accepts a request-aware body block" do
+			request = Protocol::HTTP::Request["GET", "/"]
+			page = subject.new do |request, parameters|
+				"#{request.method}:#{parameters.fetch("message")}"
+			end
+			
+			expect(page.body(request, {"message" => "Hello"})).to be == "GET:Hello"
+		end
+		
+		it "rejects a body and block together" do
+			expect do
+				subject.new(body: "Body"){"Other body"}
+			end.to raise_exception(ArgumentError, message: be =~ /body or block/)
+		end
 	end
 	
 	with "#to_html" do
-		it "passes the request and parameters to the page subclass" do
-			view_class = Class.new(Live::View) do
-				def self.name
-					"RequestView"
+		it "passes the request and parameters to the body block" do
+			body_class = Class.new do
+				def initialize(content)
+					@content = content
 				end
 				
-				def initialize(id = self.class.unique_id, data = {}, message:)
-					super(id, data)
-					@message = message
-				end
-				
-				def render(builder)
-					builder.text(@message)
+				def to_html
+					@content
 				end
 			end
-			page_class = Class.new(subject) do
-				define_method(:body) do |request, parameters|
-					resolver.make(view_class, message: "#{request.method}:#{parameters.fetch("message")}")
-				end
+			page = subject.new do |request, parameters|
+				body_class.new("#{request.method}:#{parameters.fetch("message")}")
 			end
-			resolver = Lively::Resolver.new.allow(view_class)
-			page = page_class.new(resolver: resolver)
 			request = Protocol::HTTP::Request["GET", "/"]
 			
 			html = page.to_html(request, {"message" => "Hello"})

--- a/test/lively/page.rb
+++ b/test/lively/page.rb
@@ -4,7 +4,6 @@
 # Copyright, 2026, by Samuel Williams.
 
 require "lively/page"
-require "protocol/http/request"
 
 describe Lively::Page do
 	with "#initialize" do
@@ -33,17 +32,6 @@ describe Lively::Page do
 	end
 	
 	with "#to_html" do
-		it "renders through a per-request context" do
-			page = subject.new
-			request = Protocol::HTTP::Request["GET", "/"]
-			body = Object.new
-			context = subject::Context.new(page, request, body)
-			
-			expect(context.page).to be_equal(page)
-			expect(context.request).to be_equal(request)
-			expect(context.body).to be_equal(body)
-		end
-		
 		it "renders the configured document" do
 			body = Object.new
 			def body.to_html
@@ -120,8 +108,7 @@ describe Lively::Page do
 	
 	with "#call" do
 		it "returns an HTML response" do
-			request = Protocol::HTTP::Request["GET", "/"]
-			response = subject.new(title: "Example").call(request)
+			response = subject.new(title: "Example").call
 			
 			expect(response.status).to be == 200
 			expect(response.headers["content-type"]).to be == "text/html; charset=utf-8"

--- a/test/lively/page.rb
+++ b/test/lively/page.rb
@@ -11,13 +11,14 @@ describe Lively::Page do
 		it "accepts document content and assets" do
 			page = subject.new(
 				title: "Example",
-				body: "Body",
 				icon: "/icon.png",
 				stylesheets: [{href: "/site.css", media: "screen"}],
 				imports: {"example" => "/example.js"},
 				modules: ["/application.js"],
-				body_attributes: {class: "example"},
-			)
+				body_attributes: {class: "example"}
+			) do
+				"Body"
+			end
 			
 			expect(page.title).to be == "Example"
 			expect(page.body).to be == "Body"
@@ -36,12 +37,6 @@ describe Lively::Page do
 			end
 			
 			expect(page.body(request, {"message" => "Hello"})).to be == "GET:Hello"
-		end
-		
-		it "rejects a body and block together" do
-			expect do
-				subject.new(body: "Body"){"Other body"}
-			end.to raise_exception(ArgumentError, message: be =~ /body or block/)
 		end
 	end
 	
@@ -74,7 +69,6 @@ describe Lively::Page do
 			
 			page = subject.new(
 				title: "Example",
-				body: body,
 				icon: "/icon.png",
 				stylesheets: ["/site.css", {href: "/theme.css", media: "print"}],
 				imports: {"example" => "/example.js"},
@@ -82,8 +76,10 @@ describe Lively::Page do
 				body_attributes: {
 					class: "playback",
 					data: {autoplay: "true", controls: "false"},
-				},
-			)
+				}
+			) do
+				body
+			end
 			
 			html = page.to_html
 			
@@ -124,12 +120,15 @@ describe Lively::Page do
 				"<main>Example</main>"
 			end
 			
-			html = subject.new(
+			page = subject.new(
 				title: "<Example>",
-				body: body,
 				stylesheets: ["/site.css?one=1&two=2"],
-				body_attributes: {title: 'one & "two"'},
-			).to_html
+				body_attributes: {title: 'one & "two"'}
+			) do
+				body
+			end
+			
+			html = page.to_html
 			
 			expect(html).to be(:include?, "<title>&lt;Example&gt;</title>")
 			expect(html).to be(:include?, 'href="/site.css?one=1&amp;two=2"')

--- a/test/lively/page.rb
+++ b/test/lively/page.rb
@@ -4,6 +4,7 @@
 # Copyright, 2026, by Samuel Williams.
 
 require "lively/page"
+require "lively/resolver"
 require "protocol/http/request"
 
 describe Lively::Page do
@@ -31,6 +32,66 @@ describe Lively::Page do
 	end
 	
 	with "#to_html" do
+		it "renders views supplied by a page subclass in document order" do
+			first_view = Class.new(Live::View) do
+				def self.name
+					"FirstView"
+				end
+				
+				def render(builder)
+					builder.text("First view")
+				end
+			end
+			second_view = Class.new(Live::View) do
+				def self.name
+					"SecondView"
+				end
+				
+				def render(builder)
+					builder.text("Second view")
+				end
+			end
+			page_class = Class.new(subject) do
+				define_method(:views) do |_request, _parameters|
+					[view(first_view), view(second_view)]
+				end
+			end
+			resolver = Lively::Resolver.new.allow(first_view, second_view)
+			
+			html = page_class.new(resolver: resolver).to_html
+			
+			expect(html.index("First view")).to be < html.index("Second view")
+		end
+		
+		it "passes the request and parameters to the page subclass" do
+			view_class = Class.new(Live::View) do
+				def self.name
+					"RequestView"
+				end
+				
+				def initialize(id = self.class.unique_id, data = {}, message:)
+					super(id, data)
+					@message = message
+				end
+				
+				def render(builder)
+					builder.text(@message)
+				end
+			end
+			page_class = Class.new(subject) do
+				define_method(:views) do |request, parameters|
+					[view(view_class, message: "#{request.method}:#{parameters.fetch("message")}")]
+				end
+			end
+			resolver = Lively::Resolver.new.allow(view_class)
+			page = page_class.new(resolver: resolver)
+			request = Protocol::HTTP::Request["GET", "/"]
+			
+			html = page.to_html(request, {"message" => "Hello"})
+			
+			expect(html).to be(:include?, "GET:Hello")
+		end
+		
 		it "renders the configured document" do
 			body = Object.new
 			def body.to_html

--- a/test/lively/page.rb
+++ b/test/lively/page.rb
@@ -80,7 +80,7 @@ describe Lively::Page do
 			expect(html).not.to be(:include?, 'rel="stylesheet"')
 			expect(html).not.to be(:include?, 'type="importmap"')
 			expect(html).not.to be(:include?, 'type="module"')
-			expect(html).to be(:include?, "No body specified!")
+			expect(html).not.to be(:include?, "No body specified!")
 		end
 		
 		it "escapes document values" do

--- a/test/lively/page.rb
+++ b/test/lively/page.rb
@@ -8,9 +8,11 @@ require "protocol/http/request"
 
 describe Lively::Page do
 	with "#initialize" do
-		it "accepts document assets" do
+		it "accepts document content and assets" do
+			body = Object.new
 			page = subject.new(
 				title: "Example",
+				body: body,
 				icon: "/icon.png",
 				stylesheets: [{href: "/site.css", media: "screen"}],
 				imports: {"example" => "/example.js"},
@@ -19,6 +21,7 @@ describe Lively::Page do
 			)
 			
 			expect(page.title).to be == "Example"
+			expect(page.body).to be_equal(body)
 			expect(page.icon).to be == "/icon.png"
 			expect(page.stylesheets).to be == [{href: "/site.css", media: "screen"}]
 			expect(page.imports).to be == {"example" => "/example.js"}
@@ -41,27 +44,6 @@ describe Lively::Page do
 			expect(context.body).to be_equal(body)
 		end
 		
-		it "passes the request to the body callable" do
-			body_class = Class.new do
-				def initialize(content)
-					@content = content
-				end
-				
-				def to_html
-					@content
-				end
-			end
-			body = proc do |request|
-				body_class.new("#{request.method}:#{request.path}")
-			end
-			page = subject.new(body: body)
-			request = Protocol::HTTP::Request["GET", "/?message=Hello"]
-			
-			html = page.to_html(request)
-			
-			expect(html).to be(:include?, "GET:/?message=Hello")
-		end
-		
 		it "renders the configured document" do
 			body = Object.new
 			def body.to_html
@@ -70,7 +52,7 @@ describe Lively::Page do
 			
 			page = subject.new(
 				title: "Example",
-				body: proc{body},
+				body: body,
 				icon: "/icon.png",
 				stylesheets: ["/site.css", {href: "/theme.css", media: "print"}],
 				imports: {"example" => "/example.js"},
@@ -122,7 +104,7 @@ describe Lively::Page do
 			
 			page = subject.new(
 				title: "<Example>",
-				body: proc{body},
+				body: body,
 				stylesheets: ["/site.css?one=1&two=2"],
 				body_attributes: {title: 'one & "two"'}
 			)

--- a/test/lively/page.rb
+++ b/test/lively/page.rb
@@ -31,6 +31,16 @@ describe Lively::Page do
 	end
 	
 	with "#to_html" do
+		it "renders through a per-request context" do
+			page = subject.new
+			request = Protocol::HTTP::Request["GET", "/"]
+			context = subject::Context.new(page, request)
+			
+			expect(context.page).to be_equal(page)
+			expect(context.request).to be_equal(request)
+			expect(context.body_content).to be == ""
+		end
+		
 		it "passes the request to the body method" do
 			body_class = Class.new do
 				def initialize(content)

--- a/test/lively/page.rb
+++ b/test/lively/page.rb
@@ -19,7 +19,6 @@ describe Lively::Page do
 			)
 			
 			expect(page.title).to be == "Example"
-			expect(page.body).to be_nil
 			expect(page.icon).to be == "/icon.png"
 			expect(page.stylesheets).to be == [{href: "/site.css", media: "screen"}]
 			expect(page.imports).to be == {"example" => "/example.js"}
@@ -34,14 +33,15 @@ describe Lively::Page do
 		it "renders through a per-request context" do
 			page = subject.new
 			request = Protocol::HTTP::Request["GET", "/"]
-			context = subject::Context.new(page, request)
+			body = Object.new
+			context = subject::Context.new(page, request, body)
 			
 			expect(context.page).to be_equal(page)
 			expect(context.request).to be_equal(request)
-			expect(context.body_content).to be == ""
+			expect(context.body).to be_equal(body)
 		end
 		
-		it "passes the request to the body method" do
+		it "passes the request to the body callable" do
 			body_class = Class.new do
 				def initialize(content)
 					@content = content
@@ -51,12 +51,10 @@ describe Lively::Page do
 					@content
 				end
 			end
-			page_class = Class.new(subject) do
-				define_method(:body) do |request|
-					body_class.new("#{request.method}:#{request.path}")
-				end
+			body = proc do |request|
+				body_class.new("#{request.method}:#{request.path}")
 			end
-			page = page_class.new
+			page = subject.new(body: body)
 			request = Protocol::HTTP::Request["GET", "/?message=Hello"]
 			
 			html = page.to_html(request)
@@ -70,13 +68,9 @@ describe Lively::Page do
 				XRB::MarkupString.raw("<main>Example</main>")
 			end
 			
-			page_class = Class.new(subject) do
-				define_method(:body) do |_request = nil|
-					body
-				end
-			end
-			page = page_class.new(
+			page = subject.new(
 				title: "Example",
+				body: proc{body},
 				icon: "/icon.png",
 				stylesheets: ["/site.css", {href: "/theme.css", media: "print"}],
 				imports: {"example" => "/example.js"},
@@ -126,13 +120,9 @@ describe Lively::Page do
 				"<main>Example</main>"
 			end
 			
-			page_class = Class.new(subject) do
-				define_method(:body) do |_request = nil|
-					body
-				end
-			end
-			page = page_class.new(
+			page = subject.new(
 				title: "<Example>",
+				body: proc{body},
 				stylesheets: ["/site.css?one=1&two=2"],
 				body_attributes: {title: 'one & "two"'}
 			)

--- a/test/lively/page.rb
+++ b/test/lively/page.rb
@@ -32,37 +32,6 @@ describe Lively::Page do
 	end
 	
 	with "#to_html" do
-		it "renders views supplied by a page subclass in document order" do
-			first_view = Class.new(Live::View) do
-				def self.name
-					"FirstView"
-				end
-				
-				def render(builder)
-					builder.text("First view")
-				end
-			end
-			second_view = Class.new(Live::View) do
-				def self.name
-					"SecondView"
-				end
-				
-				def render(builder)
-					builder.text("Second view")
-				end
-			end
-			page_class = Class.new(subject) do
-				define_method(:views) do |_request, _parameters|
-					[view(first_view), view(second_view)]
-				end
-			end
-			resolver = Lively::Resolver.new.allow(first_view, second_view)
-			
-			html = page_class.new(resolver: resolver).to_html
-			
-			expect(html.index("First view")).to be < html.index("Second view")
-		end
-		
 		it "passes the request and parameters to the page subclass" do
 			view_class = Class.new(Live::View) do
 				def self.name
@@ -79,8 +48,8 @@ describe Lively::Page do
 				end
 			end
 			page_class = Class.new(subject) do
-				define_method(:views) do |request, parameters|
-					[view(view_class, message: "#{request.method}:#{parameters.fetch("message")}")]
+				define_method(:body) do |request, parameters|
+					resolver.make(view_class, message: "#{request.method}:#{parameters.fetch("message")}")
 				end
 			end
 			resolver = Lively::Resolver.new.allow(view_class)

--- a/test/lively/page.rb
+++ b/test/lively/page.rb
@@ -31,7 +31,7 @@ describe Lively::Page do
 	end
 	
 	with "#to_html" do
-		it "passes the request and parameters to the body block" do
+		it "passes the request to the body method" do
 			body_class = Class.new do
 				def initialize(content)
 					@content = content
@@ -42,16 +42,16 @@ describe Lively::Page do
 				end
 			end
 			page_class = Class.new(subject) do
-				define_method(:body) do |request, parameters|
-					body_class.new("#{request.method}:#{parameters.fetch("message")}")
+				define_method(:body) do |request|
+					body_class.new("#{request.method}:#{request.path}")
 				end
 			end
 			page = page_class.new
-			request = Protocol::HTTP::Request["GET", "/"]
+			request = Protocol::HTTP::Request["GET", "/?message=Hello"]
 			
-			html = page.to_html(request, {"message" => "Hello"})
+			html = page.to_html(request)
 			
-			expect(html).to be(:include?, "GET:Hello")
+			expect(html).to be(:include?, "GET:/?message=Hello")
 		end
 		
 		it "renders the configured document" do
@@ -61,7 +61,7 @@ describe Lively::Page do
 			end
 			
 			page_class = Class.new(subject) do
-				define_method(:body) do |_request = nil, _parameters = {}|
+				define_method(:body) do |_request = nil|
 					body
 				end
 			end
@@ -117,7 +117,7 @@ describe Lively::Page do
 			end
 			
 			page_class = Class.new(subject) do
-				define_method(:body) do |_request = nil, _parameters = {}|
+				define_method(:body) do |_request = nil|
 					body
 				end
 			end

--- a/test/lively/pages/index.rb
+++ b/test/lively/pages/index.rb
@@ -139,8 +139,8 @@ describe Lively::Pages::Index do
 			content = File.read(template_path)
 			
 			expect(content).to be(:include?, "<!DOCTYPE html>")
-			expect(content).to be(:include?, "page.stylesheets")
-			expect(content).to be(:include?, "page.modules")
+			expect(content).to be(:include?, "self.stylesheets")
+			expect(content).to be(:include?, "self.modules")
 		end
 	end
 end

--- a/test/lively/pages/index.rb
+++ b/test/lively/pages/index.rb
@@ -4,7 +4,6 @@
 # Copyright, 2025-2026, by Samuel Williams.
 
 require "lively/pages/index"
-require "lively/resolver"
 require "sus/fixtures/console"
 
 describe Lively::Pages::Index do
@@ -16,7 +15,6 @@ describe Lively::Pages::Index do
 			
 			expect(index.title).to be == "Lively"
 			expect(index.body).to be_nil
-			expect(index.resolver).to be_nil
 		end
 		
 		it "accepts a custom title" do
@@ -25,30 +23,10 @@ describe Lively::Pages::Index do
 			expect(index.title).to be == "Custom Title"
 		end
 		
-		it "accepts a root view class" do
-			resolver = Lively::Resolver.new.allow(Lively::HelloWorld)
-			index = Lively::Pages::Index.new(Lively::HelloWorld, resolver: resolver)
+		it "constructs fresh bodies using a block" do
+			index = Lively::Pages::Index.new{Object.new}
 			
-			expect(index.body).to be_a(Lively::HelloWorld)
-		end
-		
-		it "constructs fresh root views using the resolver" do
-			message = Object.new
-			view_class = Class.new(Live::View) do
-				def initialize(id = self.class.unique_id, data = {}, message: nil, suffix: nil)
-					super(id, data)
-					@message = [message, suffix]
-				end
-				
-				attr :message
-			end
-			resolver = Lively::Resolver.new(message: message).allow(view_class)
-			index = Lively::Pages::Index.new(view_class, resolver: resolver, view_arguments: {suffix: "Root"})
-			first = index.body
-			second = index.body
-			
-			expect(first.message).to be == [message, "Root"]
-			expect(first).not.to be_equal(second)
+			expect(index.body).not.to be_equal(index.body)
 		end
 		
 		it "loads the XRB template" do
@@ -141,13 +119,6 @@ describe Lively::Pages::Index do
 			expect(html).not.to be(:include?, "No body specified!")
 		end
 		
-		it "requires a resolver to construct live views" do
-			index = Lively::Pages::Index.new(Lively::HelloWorld)
-			
-			expect do
-				index.to_html
-			end.to raise_exception(ArgumentError, message: be =~ /resolver/)
-		end
 	end
 	
 	with "template file" do

--- a/test/lively/pages/index.rb
+++ b/test/lively/pages/index.rb
@@ -17,21 +17,19 @@ describe Lively::Pages::Index do
 			expect(index.title).to be == "Lively"
 			expect(index.body).to be_nil
 			expect(index.resolver).to be_nil
-			expect(index.views).to be(:empty?)
 		end
 		
-		it "accepts custom title and body" do
-			index = Lively::Pages::Index.new(title: "Custom Title", body: "Custom Body")
+		it "accepts a custom title" do
+			index = Lively::Pages::Index.new(title: "Custom Title")
 			
 			expect(index.title).to be == "Custom Title"
-			expect(index.body).to be == "Custom Body"
 		end
 		
 		it "accepts a root view class" do
 			resolver = Lively::Resolver.new.allow(Lively::HelloWorld)
 			index = Lively::Pages::Index.new(Lively::HelloWorld, resolver: resolver)
 			
-			expect(index.views.first).to be_a(Lively::HelloWorld)
+			expect(index.body).to be_a(Lively::HelloWorld)
 		end
 		
 		it "constructs fresh root views using the resolver" do
@@ -46,8 +44,8 @@ describe Lively::Pages::Index do
 			end
 			resolver = Lively::Resolver.new(message: message).allow(view_class)
 			index = Lively::Pages::Index.new(view_class, resolver: resolver, view_arguments: {suffix: "Root"})
-			first = index.views.first
-			second = index.views.first
+			first = index.body
+			second = index.body
 			
 			expect(first.message).to be == [message, "Root"]
 			expect(first).not.to be_equal(second)
@@ -136,20 +134,8 @@ describe Lively::Pages::Index do
 			expect(html).to be(:include?, "application.js")
 		end
 		
-		it "includes body content when body responds to to_html" do
-			mock_body = Object.new
-			def mock_body.to_html
-				"<div>Custom Body HTML</div>"
-			end
-			
-			index = Lively::Pages::Index.new(body: mock_body)
-			html = index.to_html
-			
-			expect(html).to be(:include?, "&lt;div&gt;Custom Body HTML&lt;/div&gt;")
-		end
-		
-		it "supports pages without a body or live views" do
-			index = Lively::Pages::Index.new(body: nil)
+		it "supports pages without a root view" do
+			index = Lively::Pages::Index.new
 			html = index.to_html
 			
 			expect(html).not.to be(:include?, "No body specified!")

--- a/test/lively/pages/index.rb
+++ b/test/lively/pages/index.rb
@@ -141,8 +141,8 @@ describe Lively::Pages::Index do
 			content = File.read(template_path)
 			
 			expect(content).to be(:include?, "<!DOCTYPE html>")
-			expect(content).to be(:include?, "self.stylesheets")
-			expect(content).to be(:include?, "self.modules")
+			expect(content).to be(:include?, "page.stylesheets")
+			expect(content).to be(:include?, "page.modules")
 		end
 	end
 end

--- a/test/lively/pages/index.rb
+++ b/test/lively/pages/index.rb
@@ -4,7 +4,6 @@
 # Copyright, 2025-2026, by Samuel Williams.
 
 require "lively/pages/index"
-require "protocol/http/request"
 require "sus/fixtures/console"
 
 describe Lively::Pages::Index do
@@ -17,21 +16,12 @@ describe Lively::Pages::Index do
 			expect(index.title).to be == "Lively"
 		end
 		
-		it "accepts a custom title" do
-			index = Lively::Pages::Index.new(title: "Custom Title")
+		it "accepts a custom title and body" do
+			body = Object.new
+			index = Lively::Pages::Index.new(title: "Custom Title", body: body)
 			
 			expect(index.title).to be == "Custom Title"
-		end
-		
-		it "passes the request to the body block" do
-			request = Protocol::HTTP::Request["GET", "/example?message=Hello"]
-			index = Lively::Pages::Index.new do |request|
-				body = Object.new
-				body.define_singleton_method(:to_html){request.path}
-				body
-			end
-			
-			expect(index.to_html(request)).to be(:include?, "/example?message=Hello")
+			expect(index.body).to be_equal(body)
 		end
 		
 		it "loads the XRB template" do
@@ -122,6 +112,17 @@ describe Lively::Pages::Index do
 			html = index.to_html
 			
 			expect(html).not.to be(:include?, "No body specified!")
+		end
+		
+		it "includes a renderable body" do
+			body = Object.new
+			def body.to_html
+				XRB::MarkupString.raw("<main>Example</main>")
+			end
+			
+			index = Lively::Pages::Index.new(body: body)
+			
+			expect(index.to_html).to be(:include?, "<main>Example</main>")
 		end
 		
 	end

--- a/test/lively/pages/index.rb
+++ b/test/lively/pages/index.rb
@@ -4,6 +4,7 @@
 # Copyright, 2025-2026, by Samuel Williams.
 
 require "lively/pages/index"
+require "lively/resolver"
 require "sus/fixtures/console"
 
 describe Lively::Pages::Index do
@@ -15,6 +16,8 @@ describe Lively::Pages::Index do
 			
 			expect(index.title).to be == "Lively"
 			expect(index.body).to be_nil
+			expect(index.resolver).to be_nil
+			expect(index.views).to be(:empty?)
 		end
 		
 		it "accepts custom title and body" do
@@ -22,6 +25,29 @@ describe Lively::Pages::Index do
 			
 			expect(index.title).to be == "Custom Title"
 			expect(index.body).to be == "Custom Body"
+		end
+		
+		it "composes live views lazily using the resolver" do
+			message = Object.new
+			view_class = Class.new(Live::View) do
+				def initialize(id = self.class.unique_id, data = {}, message: nil)
+					super(id, data)
+					@message = message
+				end
+				
+				attr :message
+			end
+			resolver = Lively::Resolver.new(message: message).allow(view_class)
+			composed = false
+			
+			index = Lively::Pages::Index.new(resolver: resolver) do |page|
+				composed = true
+				page.view(view_class)
+			end
+			
+			expect(composed).to be_falsey
+			expect(index.views.first.message).to be_equal(message)
+			expect(composed).to be_truthy
 		end
 		
 		it "loads the XRB template" do
@@ -119,11 +145,74 @@ describe Lively::Pages::Index do
 			expect(html).to be(:include?, "&lt;div&gt;Custom Body HTML&lt;/div&gt;")
 		end
 		
-		it "shows fallback message when body is nil" do
+		it "supports pages without a body or live views" do
 			index = Lively::Pages::Index.new(body: nil)
 			html = index.to_html
 			
-			expect(html).to be(:include?, "No body specified!")
+			expect(html).not.to be(:include?, "No body specified!")
+		end
+		
+		it "renders multiple live views in document order" do
+			first_view = Class.new(Live::View) do
+				def self.name
+					"FirstView"
+				end
+				
+				def render(builder)
+					builder.text("First view")
+				end
+			end
+			second_view = Class.new(Live::View) do
+				def self.name
+					"SecondView"
+				end
+				
+				def render(builder)
+					builder.text("Second view")
+				end
+			end
+			resolver = Lively::Resolver.new.allow(first_view, second_view)
+			index = Lively::Pages::Index.new(resolver: resolver) do |page|
+				page.view(first_view)
+				page.view(second_view)
+			end
+			
+			html = index.to_html
+			
+			expect(html.index("First view")).to be < html.index("Second view")
+			expect(index.views.size).to be == 2
+		end
+		
+		it "composes fresh views using each request and its parameters" do
+			view_class = Class.new(Live::View) do
+				def initialize(id = self.class.unique_id, data = {}, message:)
+					super(id, data)
+					@message = message
+				end
+				
+				def render(builder)
+					builder.text(@message)
+				end
+			end
+			resolver = Lively::Resolver.new.allow(view_class)
+			index = Lively::Pages::Index.new(resolver: resolver) do |page, request, parameters|
+				page.view(view_class, message: "#{request.method}:#{parameters.fetch("message")}")
+			end
+			
+			request = Protocol::HTTP::Request["GET", "/?message=First"]
+			first = index.call(request, {"message" => "First"}).read
+			second = index.call(request, {"message" => "Second"}).read
+			
+			expect(first).to be(:include?, "GET:First")
+			expect(second).to be(:include?, "GET:Second")
+		end
+		
+		it "requires a resolver to construct live views" do
+			index = Lively::Pages::Index.new
+			
+			expect do
+				index.view(Lively::HelloWorld)
+			end.to raise_exception(ArgumentError, message: be =~ /resolver/)
 		end
 	end
 	

--- a/test/lively/pages/index.rb
+++ b/test/lively/pages/index.rb
@@ -27,27 +27,30 @@ describe Lively::Pages::Index do
 			expect(index.body).to be == "Custom Body"
 		end
 		
-		it "composes live views lazily using the resolver" do
+		it "accepts a root view class" do
+			resolver = Lively::Resolver.new.allow(Lively::HelloWorld)
+			index = Lively::Pages::Index.new(Lively::HelloWorld, resolver: resolver)
+			
+			expect(index.views.first).to be_a(Lively::HelloWorld)
+		end
+		
+		it "constructs fresh root views using the resolver" do
 			message = Object.new
 			view_class = Class.new(Live::View) do
-				def initialize(id = self.class.unique_id, data = {}, message: nil)
+				def initialize(id = self.class.unique_id, data = {}, message: nil, suffix: nil)
 					super(id, data)
-					@message = message
+					@message = [message, suffix]
 				end
 				
 				attr :message
 			end
 			resolver = Lively::Resolver.new(message: message).allow(view_class)
-			composed = false
+			index = Lively::Pages::Index.new(view_class, resolver: resolver, view_arguments: {suffix: "Root"})
+			first = index.views.first
+			second = index.views.first
 			
-			index = Lively::Pages::Index.new(resolver: resolver) do |page|
-				composed = true
-				page.view(view_class)
-			end
-			
-			expect(composed).to be_falsey
-			expect(index.views.first.message).to be_equal(message)
-			expect(composed).to be_truthy
+			expect(first.message).to be == [message, "Root"]
+			expect(first).not.to be_equal(second)
 		end
 		
 		it "loads the XRB template" do
@@ -152,66 +155,11 @@ describe Lively::Pages::Index do
 			expect(html).not.to be(:include?, "No body specified!")
 		end
 		
-		it "renders multiple live views in document order" do
-			first_view = Class.new(Live::View) do
-				def self.name
-					"FirstView"
-				end
-				
-				def render(builder)
-					builder.text("First view")
-				end
-			end
-			second_view = Class.new(Live::View) do
-				def self.name
-					"SecondView"
-				end
-				
-				def render(builder)
-					builder.text("Second view")
-				end
-			end
-			resolver = Lively::Resolver.new.allow(first_view, second_view)
-			index = Lively::Pages::Index.new(resolver: resolver) do |page|
-				page.view(first_view)
-				page.view(second_view)
-			end
-			
-			html = index.to_html
-			
-			expect(html.index("First view")).to be < html.index("Second view")
-			expect(index.views.size).to be == 2
-		end
-		
-		it "composes fresh views using each request and its parameters" do
-			view_class = Class.new(Live::View) do
-				def initialize(id = self.class.unique_id, data = {}, message:)
-					super(id, data)
-					@message = message
-				end
-				
-				def render(builder)
-					builder.text(@message)
-				end
-			end
-			resolver = Lively::Resolver.new.allow(view_class)
-			index = Lively::Pages::Index.new(resolver: resolver) do |page, request, parameters|
-				page.view(view_class, message: "#{request.method}:#{parameters.fetch("message")}")
-			end
-			
-			request = Protocol::HTTP::Request["GET", "/?message=First"]
-			first = index.call(request, {"message" => "First"}).read
-			second = index.call(request, {"message" => "Second"}).read
-			
-			expect(first).to be(:include?, "GET:First")
-			expect(second).to be(:include?, "GET:Second")
-		end
-		
 		it "requires a resolver to construct live views" do
-			index = Lively::Pages::Index.new
+			index = Lively::Pages::Index.new(Lively::HelloWorld)
 			
 			expect do
-				index.view(Lively::HelloWorld)
+				index.to_html
 			end.to raise_exception(ArgumentError, message: be =~ /resolver/)
 		end
 	end

--- a/test/lively/pages/index.rb
+++ b/test/lively/pages/index.rb
@@ -15,7 +15,6 @@ describe Lively::Pages::Index do
 			index = Lively::Pages::Index.new
 			
 			expect(index.title).to be == "Lively"
-			expect(index.body).to be_nil
 		end
 		
 		it "accepts a custom title" do
@@ -24,17 +23,15 @@ describe Lively::Pages::Index do
 			expect(index.title).to be == "Custom Title"
 		end
 		
-		it "constructs fresh bodies using a block" do
-			index = Lively::Pages::Index.new{Object.new}
-			
-			expect(index.body).not.to be_equal(index.body)
-		end
-		
 		it "passes the request to the body block" do
 			request = Protocol::HTTP::Request["GET", "/example?message=Hello"]
-			index = Lively::Pages::Index.new{|request| request.path}
+			index = Lively::Pages::Index.new do |request|
+				body = Object.new
+				body.define_singleton_method(:to_html){request.path}
+				body
+			end
 			
-			expect(index.body(request)).to be == "/example?message=Hello"
+			expect(index.to_html(request)).to be(:include?, "/example?message=Hello")
 		end
 		
 		it "loads the XRB template" do

--- a/test/lively/pages/index.rb
+++ b/test/lively/pages/index.rb
@@ -4,6 +4,7 @@
 # Copyright, 2025-2026, by Samuel Williams.
 
 require "lively/pages/index"
+require "protocol/http/request"
 require "sus/fixtures/console"
 
 describe Lively::Pages::Index do
@@ -27,6 +28,13 @@ describe Lively::Pages::Index do
 			index = Lively::Pages::Index.new{Object.new}
 			
 			expect(index.body).not.to be_equal(index.body)
+		end
+		
+		it "passes the request to the body block" do
+			request = Protocol::HTTP::Request["GET", "/example?message=Hello"]
+			index = Lively::Pages::Index.new{|request| request.path}
+			
+			expect(index.body(request)).to be == "/example?message=Hello"
 		end
 		
 		it "loads the XRB template" do

--- a/test/lively/resolver.rb
+++ b/test/lively/resolver.rb
@@ -51,5 +51,34 @@ describe Lively::Resolver do
 			expect(view).to be_a(view_class)
 			expect(view.controller).to be == state_value
 		end
+		
+		it "constructs allowed views with state and page arguments" do
+			view_class = Class.new(Live::View) do
+				def initialize(id = self.class.unique_id, data = {}, controller: nil, message:)
+					super(id, data)
+					@controller = controller
+					@message = message
+				end
+				
+				attr :controller
+				attr :message
+			end
+			
+			resolver.allow(view_class)
+			view = resolver.make(view_class, id: "root", data: {mode: "test"}, message: "Hello")
+			
+			expect(view.id).to be == "root"
+			expect(view.data[:mode]).to be == "test"
+			expect(view.controller).to be == state_value
+			expect(view.message).to be == "Hello"
+		end
+		
+		it "rejects views which are not allowed" do
+			view_class = Class.new(Live::View)
+			
+			expect do
+				resolver.make(view_class)
+			end.to raise_exception(ArgumentError, message: be =~ /not allowed/)
+		end
 	end
 end

--- a/test/lively/resolver.rb
+++ b/test/lively/resolver.rb
@@ -38,7 +38,7 @@ describe Lively::Resolver do
 		
 		it "passes state to views as keyword arguments" do
 			view_class = Class.new(Live::View) do
-				def initialize(id = self.class.unique_id, data = {}, controller: nil)
+				def initialize(id, data, controller: nil)
 					super(id, data)
 					@controller = controller
 				end
@@ -52,29 +52,31 @@ describe Lively::Resolver do
 			expect(view.controller).to be == state_value
 		end
 		
-		it "constructs allowed views with state, id and data" do
+		it "constructs allowed views with state, id, data and options" do
 			view_class = Class.new(Live::View) do
-				def initialize(id = self.class.unique_id, data = {}, controller: nil)
+				def initialize(id, data, controller: nil, option: nil)
 					super(id, data)
 					@controller = controller
+					@option = option
 				end
 				
-				attr :controller
+				attr :controller, :option
 			end
 			
 			resolver.allow(view_class)
-			view = resolver.make(view_class, id: "root", data: {mode: "test"})
+			view = resolver.root(view_class, "root", data: {mode: "test"}, option: "value")
 			
 			expect(view.id).to be == "root"
 			expect(view.data[:mode]).to be == "test"
 			expect(view.controller).to be == state_value
+			expect(view.option).to be == "value"
 		end
 		
 		it "rejects views which are not allowed" do
 			view_class = Class.new(Live::View)
 			
 			expect do
-				resolver.make(view_class)
+				resolver.root(view_class)
 			end.to raise_exception(ArgumentError, message: be =~ /not allowed/)
 		end
 	end

--- a/test/lively/resolver.rb
+++ b/test/lively/resolver.rb
@@ -52,25 +52,22 @@ describe Lively::Resolver do
 			expect(view.controller).to be == state_value
 		end
 		
-		it "constructs allowed views with state and page arguments" do
+		it "constructs allowed views with state, id and data" do
 			view_class = Class.new(Live::View) do
-				def initialize(id = self.class.unique_id, data = {}, controller: nil, message:)
+				def initialize(id = self.class.unique_id, data = {}, controller: nil)
 					super(id, data)
 					@controller = controller
-					@message = message
 				end
 				
 				attr :controller
-				attr :message
 			end
 			
 			resolver.allow(view_class)
-			view = resolver.make(view_class, id: "root", data: {mode: "test"}, message: "Hello")
+			view = resolver.make(view_class, id: "root", data: {mode: "test"})
 			
 			expect(view.id).to be == "root"
 			expect(view.data[:mode]).to be == "test"
 			expect(view.controller).to be == state_value
-			expect(view.message).to be == "Hello"
 		end
 		
 		it "rejects views which are not allowed" do

--- a/test/lively/router.rb
+++ b/test/lively/router.rb
@@ -35,8 +35,8 @@ describe Lively::Router do
 	with "exact routes" do
 		it "dispatches to callable handlers" do
 			handler = Object.new
-			def handler.call(request, parameters)
-				Protocol::HTTP::Response[200, [], ["#{request.method}:#{parameters.fetch("message")}"]]
+			def handler.call(request)
+				Protocol::HTTP::Response[200, [], ["#{request.method}:#{request.path}"]]
 			end
 			
 			router = subject.build do |router|
@@ -45,32 +45,32 @@ describe Lively::Router do
 			
 			response = router.call(request("GET", "/example?message=Hello"))
 			
-			expect(response.read).to be == "GET:Hello"
+			expect(response.read).to be == "GET:/example?message=Hello"
 		end
 		
 		it "dispatches by path and method" do
 			router = subject.build do |router|
-				router.get("/example") do |request, parameters|
-					Protocol::HTTP::Response[200, [], ["#{request.method}:#{parameters.fetch("message")}"]]
+				router.get("/example") do |request|
+					Protocol::HTTP::Response[200, [], ["#{request.method}:#{request.path}"]]
 				end
 			end
 			
 			response = router.call(request("GET", "/example?message=Hello%20World"))
 			
 			expect(response.status).to be == 200
-			expect(response.read).to be == "GET:Hello World"
+			expect(response.read).to be == "GET:/example?message=Hello%20World"
 		end
 		
-		it "supports nested query parameters" do
+		it "does not parse query parameters" do
 			router = subject.build do |router|
-				router.get("/example") do |_request, parameters|
-					Protocol::HTTP::Response[200, [], [parameters.dig("user", "name")]]
+				router.get("/example") do |request|
+					Protocol::HTTP::Response[200, [], [request.path]]
 				end
 			end
 			
-			response = router.call(request("GET", "/example?user[name]=Sam"))
+			response = router.call(request("GET", "/example?broken=%"))
 			
-			expect(response.read).to be == "Sam"
+			expect(response.read).to be == "/example?broken=%"
 		end
 		
 		it "supports routes accepting every method" do
@@ -154,12 +154,5 @@ describe Lively::Router do
 			end.to raise_exception(ArgumentError)
 		end
 		
-		it "returns bad request for malformed query parameters" do
-			router = subject.build do |router|
-				router.get("/example"){Protocol::HTTP::Response[200]}
-			end
-			
-			expect(router.call(request("GET", "/example?broken=%")).status).to be == 400
-		end
 	end
 end

--- a/test/lively/router.rb
+++ b/test/lively/router.rb
@@ -10,6 +10,28 @@ describe Lively::Router do
 		Protocol::HTTP::Request.new("http", "localhost", method, path)
 	end
 	
+	with ".build" do
+		it "builds a frozen HTTP middleware" do
+			router = subject.build do |builder|
+				builder.get("/example"){Protocol::HTTP::Response[200]}
+			end
+			
+			expect(router).to be_a(Protocol::HTTP::Middleware)
+			expect(router).to be(:frozen?)
+		end
+		
+		it "snapshots the configured routes" do
+			builder = nil
+			router = subject.build do |configured|
+				builder = configured
+			end
+			
+			builder.get("/late"){Protocol::HTTP::Response[200]}
+			
+			expect(router.call(request("GET", "/late")).status).to be == 404
+		end
+	end
+	
 	with "exact routes" do
 		it "dispatches to callable handlers" do
 			handler = Object.new
@@ -17,7 +39,7 @@ describe Lively::Router do
 				Protocol::HTTP::Response[200, [], ["#{request.method}:#{parameters.fetch("message")}"]]
 			end
 			
-			router = subject.new do |router|
+			router = subject.build do |router|
 				router.get("/example", handler)
 			end
 			
@@ -27,7 +49,7 @@ describe Lively::Router do
 		end
 		
 		it "dispatches by path and method" do
-			router = subject.new do |router|
+			router = subject.build do |router|
 				router.get("/example") do |request, parameters|
 					Protocol::HTTP::Response[200, [], ["#{request.method}:#{parameters.fetch("message")}"]]
 				end
@@ -40,7 +62,7 @@ describe Lively::Router do
 		end
 		
 		it "supports nested query parameters" do
-			router = subject.new do |router|
+			router = subject.build do |router|
 				router.get("/example") do |_request, parameters|
 					Protocol::HTTP::Response[200, [], [parameters.dig("user", "name")]]
 				end
@@ -52,7 +74,7 @@ describe Lively::Router do
 		end
 		
 		it "supports routes accepting every method" do
-			router = subject.new do |router|
+			router = subject.build do |router|
 				router.route("/example") do |request|
 					Protocol::HTTP::Response[200, [], [request.method]]
 				end
@@ -62,7 +84,7 @@ describe Lively::Router do
 		end
 		
 		it "supports routes accepting several methods" do
-			router = subject.new do |router|
+			router = subject.build do |router|
 				router.route("/example", methods: ["GET", "HEAD"]) do |request|
 					Protocol::HTTP::Response[200, [], [request.method]]
 				end
@@ -74,14 +96,17 @@ describe Lively::Router do
 	end
 	
 	with "unmatched requests" do
-		it "returns nil for an unknown path" do
-			router = subject.new
+		it "delegates an unknown path" do
+			delegate = Protocol::HTTP::Middleware.for do |_request|
+				Protocol::HTTP::Response[418]
+			end
+			router = subject.build(delegate){}
 			
-			expect(router.call(request("GET", "/missing"))).to be_nil
+			expect(router.call(request("GET", "/missing")).status).to be == 418
 		end
 		
 		it "returns method not allowed for a known path" do
-			router = subject.new do |router|
+			router = subject.build do |router|
 				router.get("/example"){Protocol::HTTP::Response[200]}
 				router.post("/example"){Protocol::HTTP::Response[201]}
 			end
@@ -98,31 +123,31 @@ describe Lively::Router do
 			handler = proc{Protocol::HTTP::Response[200]}
 			
 			expect do
-				subject.new{|router| router.get("/example", handler){Protocol::HTTP::Response[201]}}
+				subject.build{|router| router.get("/example", handler){Protocol::HTTP::Response[201]}}
 			end.to raise_exception(ArgumentError)
 		end
 		
 		it "rejects relative route paths" do
 			expect do
-				subject.new{|router| router.get("example"){}}
+				subject.build{|router| router.get("example"){}}
 			end.to raise_exception(ArgumentError)
 		end
 		
 		it "rejects complete URLs as route paths" do
 			expect do
-				subject.new{|router| router.get("https://example.com/example"){}}
+				subject.build{|router| router.get("https://example.com/example"){}}
 			end.to raise_exception(ArgumentError)
 		end
 		
 		it "rejects route paths containing a query" do
 			expect do
-				subject.new{|router| router.get("/example?mode=test"){}}
+				subject.build{|router| router.get("/example?mode=test"){}}
 			end.to raise_exception(ArgumentError)
 		end
 		
 		it "rejects duplicate routes" do
 			expect do
-				subject.new do |router|
+				subject.build do |router|
 					router.get("/example"){}
 					router.get("/example"){}
 				end
@@ -130,7 +155,7 @@ describe Lively::Router do
 		end
 		
 		it "returns bad request for malformed query parameters" do
-			router = subject.new do |router|
+			router = subject.build do |router|
 				router.get("/example"){Protocol::HTTP::Response[200]}
 			end
 			

--- a/test/lively/router.rb
+++ b/test/lively/router.rb
@@ -11,6 +11,21 @@ describe Lively::Router do
 	end
 	
 	with "exact routes" do
+		it "dispatches to callable handlers" do
+			handler = Object.new
+			def handler.call(request, parameters)
+				Protocol::HTTP::Response[200, [], ["#{request.method}:#{parameters.fetch("message")}"]]
+			end
+			
+			router = subject.new do |router|
+				router.get("/example", handler)
+			end
+			
+			response = router.call(request("GET", "/example?message=Hello"))
+			
+			expect(response.read).to be == "GET:Hello"
+		end
+		
 		it "dispatches by path and method" do
 			router = subject.new do |router|
 				router.get("/example") do |request, parameters|
@@ -79,6 +94,14 @@ describe Lively::Router do
 	end
 	
 	with "invalid input" do
+		it "rejects a handler and block together" do
+			handler = proc{Protocol::HTTP::Response[200]}
+			
+			expect do
+				subject.new{|router| router.get("/example", handler){Protocol::HTTP::Response[201]}}
+			end.to raise_exception(ArgumentError)
+		end
+		
 		it "rejects relative route paths" do
 			expect do
 				subject.new{|router| router.get("example"){}}


### PR DESCRIPTION
## Summary

- separate mutable route configuration into `Router::Builder`
- build a frozen `Router` in the `Protocol::HTTP::Middleware` chain
- allow routes to register callable request handlers as objects or blocks
- let routes construct concrete pages and views only when requested
- construct initial views through `Live::Resolver#root`
- inject shared application state by overriding Live's private `Resolver#make`
- adopt the explicit Live 0.19 `id, data` constructor contract
- migrate chatbot URL handling from `XRB::Reference` to `Protocol::URL::Reference`
- require `live ~> 0.19` and `protocol-url ~> 0.19`

## Architecture

The request flow is `Application#call → Router#call → route handler → Page#call → Page#to_html`. `Router.build` yields a mutable `Router::Builder`, snapshots its route table, and returns a frozen router middleware. Unmatched requests pass to its delegate.

A matched route selects and constructs its root view with `resolver.root`, wraps that concrete renderable body in a page, and calls the page to produce the response. Pages do not consume requests directly; route handlers retain request-specific decisions.

`Lively::Resolver` inherits Live's validation and browser-boundary behavior. It overrides only the private `make(view_class, id, data, **options)` hook to inject shared application state, so initial HTTP rendering and WebSocket reconstruction use the same construction path.

Route handlers are unary and receive the original request. Handlers that need query parameters parse them explicitly with `protocol-url`. The chatbot demonstrates parsing a mutable parameter hash and serializing it back into a redirect reference.

## Compatibility

This removes `Application#make_view`, `Application#make_page`, `Application#render_view`, and `Application#handle` in favor of explicit route composition and router delegation. `Page#call` no longer takes a request, and page bodies are concrete renderable objects.

Lively now requires Live 0.19. Custom `Live::View` initializers must accept explicit `id` and `data` positional arguments. Initial root construction should use `resolver.root(ViewClass, data: ...)`; browser reconstruction continues through `resolver.call`.

## Verification

- `bundle exec bake test` — 125 tests, 246 assertions
- test coverage — 311/311 lines, 100%
- RuboCop on changed Ruby files
- documentation coverage — 57/57 public definitions
- `git diff --check`

The CI test matrix covers supported CRuby releases and Ruby head; TruffleRuby and JRuby are no longer included.
